### PR TITLE
Add Windows support

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,21 @@
+name: Windows compatibility
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  windows-powershell:
+    runs-on: windows-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Run Windows PowerShell 5.1 self-test
+        shell: powershell
+        run: powershell -NoProfile -ExecutionPolicy Bypass -File .\claude-watch.ps1 -SelfTest

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Claude Watch
 
-Claude Watch is a lightweight, interactive macOS Terminal monitor for Claude processes and VPN connectivity.
+Claude Watch is a lightweight, interactive macOS and Windows terminal monitor for Claude processes and VPN connectivity.
 
 ## Features
 
 - Refreshes every two seconds without filling Terminal scrollback.
 - Shows the number of running processes whose command contains `claude`.
-- Detects macOS-managed VPNs and active tunnel interfaces.
+- Detects system-managed VPNs and common third-party VPN adapters.
 - Automatically stops every matching Claude process when no VPN is detected.
 - Lets you manually stop all matching processes by pressing `k`.
 - Exits cleanly with `x`, `q`, or `Control-C`.
@@ -14,27 +14,32 @@ Claude Watch is a lightweight, interactive macOS Terminal monitor for Claude pro
 > [!WARNING]
 > Claude Watch intentionally terminates processes automatically whenever its VPN checks report no connection. Because matching is case-insensitive and command-line based, it may also stop other processes whose command contains `claude`.
 
-## Requirements
+## macOS
 
-- macOS
-- The Bash version included with macOS
-- A standard Terminal that supports ANSI escape sequences
+Requirements: macOS, its included Bash version, and a Terminal that supports ANSI escape sequences.
 
-## Install
+Install and run:
 
 ```bash
 git clone https://github.com/omidkorat/claude-watch.git
 cd claude-watch
 chmod +x claude-watch.sh
-```
-
-## Run
-
-```bash
 ./claude-watch.sh
 ```
 
-While it is running:
+## Windows
+
+Requirements: Windows 10 or 11 and Windows PowerShell 5.1 or later.
+
+Clone the repository, open PowerShell in its folder, and run:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\claude-watch.ps1
+```
+
+The execution-policy option applies only to that invocation and does not change the system policy.
+
+## Controls
 
 - Press `k` to stop every detected Claude process.
 - Press `x` or `q` to exit.
@@ -45,7 +50,7 @@ While it is running:
 - Yellow: Claude is running while a VPN is connected.
 - Red: VPN disconnected, auto-kill armed, or an automatic stop was triggered.
 
-## VPN detection
+## VPN detection on macOS
 
 Claude Watch checks, in order:
 
@@ -54,6 +59,16 @@ Claude Watch checks, in order:
 3. Default routes using `utun`, `ppp`, or `ipsec` interfaces.
 
 Some Apple services and third-party networking tools may also use tunnel interfaces. Review the script's behavior for your setup before relying on it as a security control.
+
+## VPN detection on Windows
+
+The PowerShell version checks, in order:
+
+1. Connected Windows VPN profiles reported by `Get-VpnConnection`.
+2. Active adapters reported by `Get-NetAdapter` whose names identify common VPN technologies or providers.
+3. Connected VPN-like adapters reported by `Win32_NetworkAdapter` as a compatibility fallback.
+
+The Windows version includes a non-destructive `-SelfTest` mode. GitHub Actions runs it on Windows PowerShell 5.1 for every pull request and every push to `main`.
 
 ## License
 

--- a/claude-watch.ps1
+++ b/claude-watch.ps1
@@ -1,0 +1,259 @@
+#Requires -Version 5.1
+
+[CmdletBinding()]
+param(
+    [switch]$SelfTest
+)
+
+$RefreshSeconds = 2
+$VpnAdapterPattern = '(?i)(vpn|wireguard|wintun|openvpn|tailscale|nordlynx|proton|mullvad|anyconnect|globalprotect|fortinet|tap[-_ ]|tun[-_ ])'
+
+function Test-ClaudeProcess {
+    param(
+        [Parameter(Mandatory = $true)]
+        $Process
+    )
+
+    if ([int]$Process.ProcessId -eq $PID) {
+        return $false
+    }
+
+    return (([string]$Process.Name -match '(?i)claude') -or
+        ([string]$Process.CommandLine -match '(?i)claude'))
+}
+
+function Get-ClaudeProcesses {
+    try {
+        return @(Get-CimInstance -ClassName Win32_Process -ErrorAction Stop |
+            Where-Object { Test-ClaudeProcess $_ })
+    }
+    catch {
+        return @(Get-Process -ErrorAction SilentlyContinue |
+            Where-Object { $_.Id -ne $PID -and $_.ProcessName -match '(?i)claude' } |
+            ForEach-Object {
+                [pscustomobject]@{
+                    ProcessId  = $_.Id
+                    Name       = $_.ProcessName
+                    CommandLine = $null
+                }
+            })
+    }
+}
+
+function Test-VpnAdapter {
+    param(
+        [Parameter(Mandatory = $true)]
+        $Adapter
+    )
+
+    $description = '{0} {1}' -f ([string]$Adapter.Name), ([string]$Adapter.InterfaceDescription)
+    return ($description -match $VpnAdapterPattern)
+}
+
+function Get-VpnStatus {
+    $vpnNames = @()
+
+    if (Get-Command -Name Get-VpnConnection -ErrorAction SilentlyContinue) {
+        try {
+            $vpnNames += @(Get-VpnConnection -ErrorAction Stop |
+                Where-Object { $_.ConnectionStatus -eq 'Connected' } |
+                ForEach-Object { $_.Name })
+        }
+        catch {}
+
+        try {
+            $vpnNames += @(Get-VpnConnection -AllUserConnection -ErrorAction Stop |
+                Where-Object { $_.ConnectionStatus -eq 'Connected' } |
+                ForEach-Object { $_.Name })
+        }
+        catch {}
+    }
+
+    $vpnNames = @($vpnNames | Where-Object { $_ } | Sort-Object -Unique)
+    if ($vpnNames.Count -gt 0) {
+        return 'Connected: {0}' -f ($vpnNames -join ', ')
+    }
+
+    if (Get-Command -Name Get-NetAdapter -ErrorAction SilentlyContinue) {
+        try {
+            $adapters = @(Get-NetAdapter -ErrorAction Stop |
+                Where-Object { $_.Status -eq 'Up' -and (Test-VpnAdapter $_) })
+            if ($adapters.Count -gt 0) {
+                return 'Connected (active adapter: {0})' -f (($adapters.Name | Sort-Object -Unique) -join ', ')
+            }
+        }
+        catch {}
+    }
+
+    try {
+        $adapters = @(Get-CimInstance -ClassName Win32_NetworkAdapter -ErrorAction Stop |
+            Where-Object { $_.NetConnectionStatus -eq 2 -and (Test-VpnAdapter $_) })
+        if ($adapters.Count -gt 0) {
+            return 'Connected (active adapter: {0})' -f (($adapters.Name | Sort-Object -Unique) -join ', ')
+        }
+    }
+    catch {}
+
+    return $null
+}
+
+function Stop-ClaudeProcesses {
+    foreach ($attempt in 1..2) {
+        $processes = @(Get-ClaudeProcesses)
+        foreach ($process in $processes) {
+            Stop-Process -Id $process.ProcessId -Force -ErrorAction SilentlyContinue
+        }
+
+        if ($attempt -eq 1 -and $processes.Count -gt 0) {
+            Start-Sleep -Milliseconds 300
+        }
+    }
+}
+
+function Write-StatusLine {
+    param(
+        [AllowEmptyString()]
+        [string]$Text,
+
+        [ConsoleColor]$Color = [ConsoleColor]::Gray
+    )
+
+    $width = [Math]::Max(20, [Console]::WindowWidth - 1)
+    if ($Text.Length -gt $width) {
+        $Text = $Text.Substring(0, $width)
+    }
+
+    Write-Host $Text.PadRight($width) -ForegroundColor $Color
+}
+
+function Show-Status {
+    param(
+        [object[]]$ClaudeProcesses,
+        [string]$VpnStatus,
+        [bool]$AutoKilled
+    )
+
+    [Console]::SetCursorPosition(0, 0)
+    Write-StatusLine 'Claude Watch - Windows' Cyan
+    Write-StatusLine ('Updated: {0:yyyy-MM-dd HH:mm:ss}  |  Refresh: {1}s' -f (Get-Date), $RefreshSeconds)
+    Write-StatusLine ''
+
+    if ($ClaudeProcesses.Count -eq 0) {
+        Write-StatusLine 'No Claude processes are running.' Green
+    }
+    elseif ($VpnStatus) {
+        Write-StatusLine ('CLAUDE IS RUNNING: {0} process(es)' -f $ClaudeProcesses.Count) Yellow
+    }
+    else {
+        Write-StatusLine ('CLAUDE IS RUNNING: {0} process(es)' -f $ClaudeProcesses.Count) Red
+    }
+
+    if ($AutoKilled) {
+        Write-StatusLine 'Claude was automatically stopped because the VPN is disconnected.' Red
+    }
+    else {
+        Write-StatusLine ''
+    }
+
+    Write-StatusLine ''
+    if ($VpnStatus) {
+        Write-StatusLine ('VPN: {0}' -f $VpnStatus) Green
+    }
+    else {
+        Write-StatusLine 'VPN: Not connected - Claude auto-kill is armed' Red
+    }
+
+    Write-StatusLine ''
+    Write-StatusLine 'Options: [K] Kill all Claude processes   [X] Exit'
+    Write-StatusLine 'Monitor keeps refreshing automatically.'
+}
+
+function Invoke-SelfTest {
+    $claudeSample = [pscustomobject]@{
+        ProcessId  = 10001
+        Name       = 'Claude.exe'
+        CommandLine = 'C:\Program Files\Claude\Claude.exe'
+    }
+    $commandSample = [pscustomobject]@{
+        ProcessId  = 10002
+        Name       = 'node.exe'
+        CommandLine = 'node.exe C:\tools\claude-helper.js'
+    }
+    $otherSample = [pscustomobject]@{
+        ProcessId  = 10003
+        Name       = 'notepad.exe'
+        CommandLine = 'notepad.exe'
+    }
+    $vpnSample = [pscustomobject]@{
+        Name                 = 'WireGuard Tunnel'
+        InterfaceDescription = 'WireGuard Tunnel Adapter'
+    }
+    $ethernetSample = [pscustomobject]@{
+        Name                 = 'Ethernet'
+        InterfaceDescription = 'Intel Ethernet Controller'
+    }
+
+    if (-not (Test-ClaudeProcess $claudeSample)) { throw 'Claude name detection failed.' }
+    if (-not (Test-ClaudeProcess $commandSample)) { throw 'Claude command-line detection failed.' }
+    if (Test-ClaudeProcess $otherSample) { throw 'Unrelated process detection failed.' }
+    if (-not (Test-VpnAdapter $vpnSample)) { throw 'VPN adapter detection failed.' }
+    if (Test-VpnAdapter $ethernetSample) { throw 'Unrelated adapter detection failed.' }
+
+    $null = @(Get-ClaudeProcesses)
+    $null = Get-VpnStatus
+    Write-Host 'Claude Watch Windows self-test passed.' -ForegroundColor Green
+}
+
+if ($SelfTest) {
+    Invoke-SelfTest
+    exit 0
+}
+
+$originalCursorVisible = [Console]::CursorVisible
+$exitRequested = $false
+
+try {
+    [Console]::Clear()
+    [Console]::CursorVisible = $false
+
+    while (-not $exitRequested) {
+        $claudeProcesses = @(Get-ClaudeProcesses)
+        $vpnStatus = Get-VpnStatus
+        $autoKilled = $false
+
+        if ($claudeProcesses.Count -gt 0 -and -not $vpnStatus) {
+            Stop-ClaudeProcesses
+            $autoKilled = $true
+            $claudeProcesses = @(Get-ClaudeProcesses)
+        }
+
+        Show-Status -ClaudeProcesses $claudeProcesses -VpnStatus $vpnStatus -AutoKilled $autoKilled
+
+        $deadline = (Get-Date).AddSeconds($RefreshSeconds)
+        :waitLoop while ((Get-Date) -lt $deadline) {
+            if ([Console]::KeyAvailable) {
+                $key = [Console]::ReadKey($true).Key
+                switch ($key) {
+                    'K' {
+                        Stop-ClaudeProcesses
+                        break waitLoop
+                    }
+                    'X' {
+                        $exitRequested = $true
+                        break waitLoop
+                    }
+                    'Q' {
+                        $exitRequested = $true
+                        break waitLoop
+                    }
+                }
+            }
+
+            Start-Sleep -Milliseconds 100
+        }
+    }
+}
+finally {
+    [Console]::CursorVisible = $originalCursorVisible
+    Write-Host 'Monitor stopped.' -ForegroundColor Cyan
+}


### PR DESCRIPTION
## What changed

- Added a native Windows PowerShell 5.1 implementation of Claude Watch.
- Added Windows VPN profile and active VPN adapter detection.
- Added the same automatic Claude termination, process count, status colors, and keyboard controls as the macOS version.
- Added a non-destructive self-test and a Windows GitHub Actions workflow.
- Expanded the README with Windows installation, usage, and detection details.

## Why

Windows users requested a compatible version. A native PowerShell implementation provides Windows process and network integration without requiring Bash or third-party runtimes.

## User impact

Windows 10 and 11 users can run `claude-watch.ps1` with Windows PowerShell 5.1. When no VPN is detected, the monitor automatically stops matching Claude processes, consistent with the macOS behavior.

## Validation

- PowerShell self-tests cover Claude name and command-line matching, unrelated-process rejection, VPN-adapter matching, and unrelated-adapter rejection.
- GitHub Actions runs the self-test on `windows-latest` with Windows PowerShell 5.1.
- Repository whitespace validation passed with `git diff --check`.
