### PR TITLE
Fix Claude PID process detection

### DIFF
--- a/claude-watch.sh
+++ b/claude-watch.sh
@@ -20,7 +20,9 @@ cleanup() {
 trap cleanup INT TERM HUP
 
 claude_pids() {
-    pgrep -ix 'Claude' 2>/dev/null || true
+    # Match process names only, including Claude helpers, without scanning
+    # unrelated command-line arguments that happen to contain "claude".
+    pgrep -i '^Claude($|[ -])' 2>/dev/null || true
 }
 
 vpn_status() {

--- a/claude-watch.sh
+++ b/claude-watch.sh
@@ -20,10 +20,7 @@ cleanup() {
 trap cleanup INT TERM HUP
 
 claude_pids() {
-    ps -axo pid=,command= | awk -v self="$$" '
-        $1 != self && tolower($0) ~ /claude/ &&
-        $0 !~ /[a]wk -v self=/ { print $1 }
-    ' | sort -u
+    pgrep -ix 'Claude' 2>/dev/null || true
 }
 
 vpn_status() {


### PR DESCRIPTION
## Summary

Prevent false-positive Claude process detection by matching macOS process names instead of scanning full command-line arguments, while continuing to include Claude helper processes.

## Credit

Thanks to @ba-amin for identifying the false-positive behavior, proposing the process-name approach, and opening this pull request.

## Problem

The previous implementation searched every process command line for the word `claude`. This could incorrectly identify and terminate unrelated processes, including repository commands whose arguments happened to contain `claude-watch`.

An exact `Claude` name match avoids those false positives but misses real processes such as `Claude Helper (Renderer)` and `claude-ios-sim`.

## Change

Use `pgrep`'s default process-name matching with an anchored pattern:

```bash
pgrep -i '^Claude($|[ -])' 2>/dev/null || true
```

This matches `Claude`, names beginning with `Claude `, and names beginning with `Claude-`, without inspecting unrelated command-line arguments.

## Validation

- Both installed and repository scripts pass `bash -n`.
- A behavioral test using real macOS processes confirmed matches for `Claude`, `Claude Helper (Renderer)`, and `claude-ios-sim`.
- The same test confirmed that `ClaudeNot` is excluded.
- The contributor is credited as co-author on the final implementation commit.
