### PR TITLE
Detect VyprVPN tunnel routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Claude Watch checks, in order:
 
 1. Connected VPN services reported by `scutil --nc list`.
 2. Active `utun` tunnel interfaces reported by `scutil --nwi`.
-3. Default routes using `utun`, `ppp`, or `ipsec` interfaces.
+3. Full-tunnel routes using `utun`, `tun`, `tap`, `ppp`, or `ipsec` interfaces, including OpenVPN's `0/1` plus `128/1` routing pattern used by VyprVPN.
 
 Some Apple services and third-party networking tools may also use tunnel interfaces. Review the script's behavior for your setup before relying on it as a security control.
 

--- a/claude-watch.sh
+++ b/claude-watch.sh
@@ -27,7 +27,7 @@ claude_pids() {
 }
 
 vpn_status() {
-    local connected_service nwi_interfaces default_interface
+    local connected_service nwi_interfaces routed_tunnels
 
     connected_service=$(scutil --nc list 2>/dev/null |
         sed -nE '/\(Connected\)/s/.*"([^"]+)".*/\1/p' |
@@ -51,9 +51,24 @@ vpn_status() {
         return 0
     fi
 
-    default_interface=$(route -n get default 2>/dev/null | awk '/interface:/ {print $2; exit}')
-    if [[ "$default_interface" == utun* || "$default_interface" == ppp* || "$default_interface" == ipsec* ]]; then
-        printf 'Connected (default route: %s)' "$default_interface"
+    # OpenVPN clients such as VyprVPN may keep the normal default route while
+    # sending traffic through two half-default routes (0/1 and 128/1).
+    routed_tunnels=$(netstat -rn -f inet 2>/dev/null | awk '
+        /^Destination/ {
+            for (i = 1; i <= NF; i++)
+                if ($i == "Netif") interface_column = i
+            next
+        }
+        interface_column &&
+        ($1 == "default" || $1 == "0/1" || $1 == "0.0.0.0/1" ||
+         $1 == "128/1" || $1 == "128.0/1" || $1 == "128.0.0.0/1") &&
+        $interface_column ~ /^(utun|tun|tap|ppp|ipsec)[0-9]*$/ {
+            print $interface_column
+        }
+    ' | sort -u | paste -sd ',' - | sed 's/,/, /g')
+
+    if [[ -n "$routed_tunnels" ]]; then
+        printf 'Connected (routed tunnel: %s)' "$routed_tunnels"
         return 0
     fi
 


### PR DESCRIPTION
## What changed

- Added macOS detection for VPN traffic routed through tunnel interfaces.
- Recognizes OpenVPN's two half-default routes (`0/1` and `128/1`).
- Documents VyprVPN and the expanded tunnel-route check.

## Why

VyprVPN can be fully connected without appearing in `scutil --nc list` or `scutil --nwi`. It keeps the ordinary Wi-Fi default route and installs two half-default routes through its `utun` interface, so the previous detector incorrectly reported no VPN.

## User impact

Claude Watch now recognizes VyprVPN's OpenVPN connection and no longer triggers automatic Claude termination while that tunnel is active.

## Validation

- Bash syntax validation passed for both the installed and repository scripts.
- Live validation against an active VyprVPN session reported `VPN: Connected (routed tunnel: utun8)`.
- Repository whitespace validation passed with `git diff --check`.
