### PR TITLE
Add VS Code VPN kill-switch (code-watch) + companion extension

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,6 +16,10 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Run Windows PowerShell 5.1 self-test
+      - name: Run Windows PowerShell 5.1 self-test (claude-watch)
         shell: powershell
         run: powershell -NoProfile -ExecutionPolicy Bypass -File .\claude-watch.ps1 -SelfTest
+
+      - name: Run Windows PowerShell 5.1 self-test (code-watch)
+        shell: powershell
+        run: powershell -NoProfile -ExecutionPolicy Bypass -File .\code-watch.ps1 -SelfTest

--- a/README.md
+++ b/README.md
@@ -70,6 +70,45 @@ The PowerShell version checks, in order:
 
 The Windows version includes a non-destructive `-SelfTest` mode. GitHub Actions runs it on Windows PowerShell 5.1 for every pull request and every push to `main`.
 
+## VS Code VPN kill-switch (code-watch)
+
+`code-watch.sh` (macOS) and `code-watch.ps1` (Windows) do the same VPN detection as above, but instead of killing processes they **freeze the entire VS Code process tree** — the app, every helper process, and anything an extension spawned under it (language servers, integrated-terminal shells, CLIs) — with `SIGSTOP`/`NtSuspendProcess` whenever the VPN drops, and wake it back up with `SIGCONT`/`NtResumeProcess` once the VPN reconnects. No windows or unsaved buffers are lost; VS Code is simply unresponsive while paused.
+
+> [!WARNING]
+> Pausing the whole process tree also freezes anything running inside VS Code, including integrated terminals and other extensions (e.g. Claude Code CLI sessions) — you won't be able to interact with them until the VPN comes back.
+
+Run standalone for testing:
+
+```bash
+./code-watch.sh                       # interactive, like claude-watch.sh
+./code-watch.sh --daemon /tmp/status  # headless, writes KEY=VALUE status lines
+```
+
+```powershell
+powershell -File .\code-watch.ps1                                   # interactive
+powershell -File .\code-watch.ps1 -Daemon -StatusFile C:\temp\status # headless
+```
+
+In daemon mode, drop `pause`, `resume`, or `stop` into `<status-file>.cmd` to control it externally.
+
+### VS Code extension
+
+`vscode-extension/` wraps these scripts as a VS Code extension, so the kill-switch is armed automatically every time VS Code opens instead of depending on someone remembering to run a script in a terminal.
+
+It launches the appropriate script as a detached background daemon on startup and surfaces status in a dedicated **Code Watch** view in the Activity Bar: VPN state, tunnel interface, public IP (what a leak would actually expose, not just the tunnel's local address), frozen-process count, and last-check time. The Activity Bar icon gets a badge only while VS Code is actually paused, so there's something to notice without opening the panel. An optional status-bar indicator is also available if you keep your status bar visible. Commands: `Code Watch: Start/Stop Monitoring`, `Pause/Resume Now`.
+
+Because the extension host is itself part of the frozen process tree, it can't show a live countdown while paused — see `vscode-extension/README.md` for the details and workaround (watching from a separate terminal outside VS Code).
+
+Build it with:
+
+```bash
+cd vscode-extension
+npm install
+npm run build
+```
+
+Then run it from the Extension Development Host (`F5` in VS Code) or package it with `vsce package`.
+
 ## License
 
 [MIT](LICENSE)

--- a/code-watch.ps1
+++ b/code-watch.ps1
@@ -1,0 +1,502 @@
+#Requires -Version 5.1
+
+# Suspends and resumes the entire VS Code process tree based on VPN
+# connectivity on Windows. Unlike claude-watch.ps1 (which kills Claude
+# processes), this script freezes VS Code with NtSuspendProcess so no
+# code, extension, or integrated-terminal process under it can touch the
+# network while the VPN is down, then wakes it back up with
+# NtResumeProcess once the VPN returns. No windows or unsaved buffers
+# are lost.
+
+[CmdletBinding()]
+param(
+    [switch]$SelfTest,
+    [switch]$Daemon,
+    [string]$StatusFile,
+    [string]$AppProcessName = 'Code'
+)
+
+$RefreshSeconds = 2
+$VpnAdapterPattern = '(?i)(vpn|wireguard|wintun|openvpn|tailscale|nordlynx|proton|mullvad|anyconnect|globalprotect|fortinet|tap[-_ ]|tun[-_ ])'
+
+Add-Type -Namespace CodeWatch -Name NativeMethods -MemberDefinition @'
+[System.Runtime.InteropServices.DllImport("ntdll.dll")]
+public static extern uint NtSuspendProcess(System.IntPtr processHandle);
+[System.Runtime.InteropServices.DllImport("ntdll.dll")]
+public static extern uint NtResumeProcess(System.IntPtr processHandle);
+[System.Runtime.InteropServices.DllImport("kernel32.dll", SetLastError = true)]
+public static extern System.IntPtr OpenProcess(uint processAccess, bool bInheritHandle, int processId);
+[System.Runtime.InteropServices.DllImport("kernel32.dll", SetLastError = true)]
+public static extern bool CloseHandle(System.IntPtr hObject);
+'@ -ErrorAction SilentlyContinue
+
+$ProcessAllAccess = 0x1FFFFF
+
+function Test-VpnAdapter {
+    param(
+        [Parameter(Mandatory = $true)]
+        $Adapter
+    )
+
+    $description = '{0} {1}' -f ([string]$Adapter.Name), ([string]$Adapter.InterfaceDescription)
+    return ($description -match $VpnAdapterPattern)
+}
+
+function Get-VpnStatus {
+    $vpnNames = @()
+
+    if (Get-Command -Name Get-VpnConnection -ErrorAction SilentlyContinue) {
+        try {
+            $vpnNames += @(Get-VpnConnection -ErrorAction Stop |
+                Where-Object { $_.ConnectionStatus -eq 'Connected' } |
+                ForEach-Object { $_.Name })
+        }
+        catch {}
+
+        try {
+            $vpnNames += @(Get-VpnConnection -AllUserConnection -ErrorAction Stop |
+                Where-Object { $_.ConnectionStatus -eq 'Connected' } |
+                ForEach-Object { $_.Name })
+        }
+        catch {}
+    }
+
+    $vpnNames = @($vpnNames | Where-Object { $_ } | Sort-Object -Unique)
+    if ($vpnNames.Count -gt 0) {
+        return 'Connected: {0}' -f ($vpnNames -join ', ')
+    }
+
+    if (Get-Command -Name Get-NetAdapter -ErrorAction SilentlyContinue) {
+        try {
+            $adapters = @(Get-NetAdapter -ErrorAction Stop |
+                Where-Object { $_.Status -eq 'Up' -and (Test-VpnAdapter $_) })
+            if ($adapters.Count -gt 0) {
+                return 'Connected (active adapter: {0})' -f (($adapters.Name | Sort-Object -Unique) -join ', ')
+            }
+        }
+        catch {}
+    }
+
+    try {
+        $adapters = @(Get-CimInstance -ClassName Win32_NetworkAdapter -ErrorAction Stop |
+            Where-Object { $_.NetConnectionStatus -eq 2 -and (Test-VpnAdapter $_) })
+        if ($adapters.Count -gt 0) {
+            return 'Connected (active adapter: {0})' -f (($adapters.Name | Sort-Object -Unique) -join ', ')
+        }
+    }
+    catch {}
+
+    return $null
+}
+
+function Get-VpnTunnelInterface {
+    # First VPN-matching adapter that actually carries an IPv4 address,
+    # independent of which check in Get-VpnStatus flagged it connected.
+    if (-not (Get-Command -Name Get-NetAdapter -ErrorAction SilentlyContinue)) { return $null }
+
+    try {
+        $adapters = @(Get-NetAdapter -ErrorAction Stop | Where-Object { $_.Status -eq 'Up' -and (Test-VpnAdapter $_) })
+    }
+    catch {
+        return $null
+    }
+
+    foreach ($adapter in $adapters) {
+        try {
+            $addr = Get-NetIPAddress -InterfaceIndex $adapter.ifIndex -AddressFamily IPv4 -ErrorAction Stop |
+                Select-Object -First 1 -ExpandProperty IPAddress
+        }
+        catch {
+            $addr = $null
+        }
+        if ($addr) {
+            return $adapter.Name
+        }
+    }
+
+    return $null
+}
+
+function Get-PublicIp {
+    # The externally-visible IP — what a leak would actually expose —
+    # tried against a couple of providers in case one is blocked or down.
+    foreach ($url in 'https://api.ipify.org', 'https://ifconfig.me/ip', 'https://icanhazip.com') {
+        try {
+            $ip = (Invoke-RestMethod -Uri $url -TimeoutSec 3 -ErrorAction Stop).ToString().Trim()
+            if ($ip) { return $ip }
+        }
+        catch {}
+    }
+    return $null
+}
+
+function Get-CodeProcessTree {
+    # Every root "Code.exe"-style process plus its full descendant tree,
+    # walked from a single process snapshot so nothing spawned by an
+    # extension (language servers, integrated-terminal shells, helper
+    # CLIs) is left able to reach the network while the tree is frozen.
+    param(
+        [object[]]$ProcessList
+    )
+
+    if (-not $ProcessList) {
+        try {
+            $ProcessList = @(Get-CimInstance -ClassName Win32_Process -ErrorAction Stop)
+        }
+        catch {
+            return @()
+        }
+    }
+
+    $childrenOf = @{}
+    foreach ($p in $ProcessList) {
+        $parent = [int]$p.ParentProcessId
+        if (-not $childrenOf.ContainsKey($parent)) {
+            $childrenOf[$parent] = New-Object System.Collections.Generic.List[int]
+        }
+        $childrenOf[$parent].Add([int]$p.ProcessId)
+    }
+
+    $selfId = $PID
+    $roots = @($ProcessList |
+        Where-Object { $_.Name -eq "$AppProcessName.exe" -and [int]$_.ProcessId -ne $selfId } |
+        ForEach-Object { [int]$_.ProcessId })
+
+    $visited = @{}
+    $queue = New-Object System.Collections.Generic.Queue[int]
+    foreach ($r in $roots) {
+        if (-not $visited.ContainsKey($r)) {
+            $visited[$r] = $true
+            $queue.Enqueue($r)
+        }
+    }
+
+    $result = New-Object System.Collections.Generic.List[int]
+    while ($queue.Count -gt 0) {
+        $currentPid = $queue.Dequeue()
+        if ($currentPid -ne $selfId) {
+            $result.Add($currentPid)
+        }
+        if ($childrenOf.ContainsKey($currentPid)) {
+            foreach ($c in $childrenOf[$currentPid]) {
+                if (-not $visited.ContainsKey($c)) {
+                    $visited[$c] = $true
+                    $queue.Enqueue($c)
+                }
+            }
+        }
+    }
+
+    return @($result)
+}
+
+function Suspend-ProcessById {
+    param([int]$ProcessId)
+    $handle = [CodeWatch.NativeMethods]::OpenProcess($ProcessAllAccess, $false, $ProcessId)
+    if ($handle -ne [System.IntPtr]::Zero) {
+        [void][CodeWatch.NativeMethods]::NtSuspendProcess($handle)
+        [void][CodeWatch.NativeMethods]::CloseHandle($handle)
+    }
+}
+
+function Resume-ProcessById {
+    param([int]$ProcessId)
+    $handle = [CodeWatch.NativeMethods]::OpenProcess($ProcessAllAccess, $false, $ProcessId)
+    if ($handle -ne [System.IntPtr]::Zero) {
+        [void][CodeWatch.NativeMethods]::NtResumeProcess($handle)
+        [void][CodeWatch.NativeMethods]::CloseHandle($handle)
+    }
+}
+
+function Suspend-CodeTree {
+    $pids = @(Get-CodeProcessTree)
+    foreach ($p in $pids) { Suspend-ProcessById -ProcessId $p }
+    return $pids.Count -gt 0
+}
+
+function Resume-CodeTree {
+    $pids = @(Get-CodeProcessTree)
+    foreach ($p in $pids) { Resume-ProcessById -ProcessId $p }
+}
+
+function Write-DaemonStatus {
+    param(
+        [string]$VpnState,
+        [string]$Detail,
+        [string]$State,
+        [int]$ProcessCount,
+        [string]$Iface,
+        [string]$IpAddress,
+        [long]$PausedAt
+    )
+
+    if (-not $StatusFile) { return }
+    $tmp = "$StatusFile.tmp.$PID"
+    @(
+        "VPN=$VpnState"
+        "DETAIL=$Detail"
+        "STATE=$State"
+        "PIDS=$ProcessCount"
+        "IFACE=$Iface"
+        "IP=$IpAddress"
+        "PAUSED_AT=$PausedAt"
+        "UPDATED=$([DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ'))"
+    ) | Set-Content -Path $tmp -Encoding UTF8
+    Move-Item -Path $tmp -Destination $StatusFile -Force
+}
+
+function Get-DaemonCommand {
+    $cmdFile = "$StatusFile.cmd"
+    if (-not $StatusFile -or -not (Test-Path $cmdFile)) { return $null }
+    $cmd = (Get-Content -Path $cmdFile -Raw -ErrorAction SilentlyContinue)
+    Remove-Item -Path $cmdFile -Force -ErrorAction SilentlyContinue
+    if ($cmd) { return $cmd.Trim() }
+    return $null
+}
+
+function Write-StatusLine {
+    param(
+        [AllowEmptyString()]
+        [string]$Text,
+
+        [ConsoleColor]$Color = [ConsoleColor]::Gray
+    )
+
+    $width = [Math]::Max(20, [Console]::WindowWidth - 1)
+    if ($Text.Length -gt $width) {
+        $Text = $Text.Substring(0, $width)
+    }
+
+    Write-Host $Text.PadRight($width) -ForegroundColor $Color
+}
+
+function Show-Status {
+    param(
+        [int]$ProcessCount,
+        [string]$VpnStatus,
+        [bool]$Paused,
+        [string]$TunnelIface,
+        [string]$PublicIp,
+        [long]$PausedAt
+    )
+
+    [Console]::SetCursorPosition(0, 0)
+    Write-StatusLine 'VS Code Watch - Windows' Cyan
+    Write-StatusLine ('Updated: {0:yyyy-MM-dd HH:mm:ss}  |  Refresh: {1}s' -f (Get-Date), $RefreshSeconds)
+    Write-StatusLine ''
+
+    if ($Paused) {
+        $elapsed = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds() - $PausedAt
+        Write-StatusLine ('VS CODE IS PAUSED ({0} process(es) frozen, {1}s so far)' -f $ProcessCount, $elapsed) Red
+    }
+    elseif ($ProcessCount -eq 0) {
+        Write-StatusLine 'No VS Code processes detected.' Green
+    }
+    elseif ($VpnStatus) {
+        Write-StatusLine ('VS Code running: {0} process(es)' -f $ProcessCount) Green
+    }
+    else {
+        Write-StatusLine ('VS Code running: {0} process(es)' -f $ProcessCount) Yellow
+    }
+
+    Write-StatusLine ''
+    if ($VpnStatus) {
+        Write-StatusLine ('VPN: {0}' -f $VpnStatus) Green
+    }
+    else {
+        Write-StatusLine 'VPN: Not connected - VS Code auto-pause is armed' Red
+    }
+
+    Write-StatusLine ('Tunnel interface: {0}' -f $(if ($TunnelIface) { $TunnelIface } else { 'none' }))
+    Write-StatusLine ('Public IP: {0}' -f $(if ($PublicIp) { $PublicIp } else { 'unknown' }))
+
+    Write-StatusLine ''
+    Write-StatusLine 'Options: [P] Pause now   [R] Resume now   [X] Exit'
+    Write-StatusLine 'Monitor keeps refreshing automatically.'
+}
+
+function Invoke-SelfTest {
+    $vpnSample = [pscustomobject]@{
+        Name                 = 'WireGuard Tunnel'
+        InterfaceDescription = 'WireGuard Tunnel Adapter'
+    }
+    $ciscoSample = [pscustomobject]@{
+        Name                 = 'Ethernet 2'
+        InterfaceDescription = 'Cisco AnyConnect Secure Mobility Client Virtual Adapter'
+    }
+    $ethernetSample = [pscustomobject]@{
+        Name                 = 'Ethernet'
+        InterfaceDescription = 'Intel Ethernet Controller'
+    }
+
+    if (-not (Test-VpnAdapter $vpnSample)) { throw 'VPN adapter detection failed.' }
+    if (-not (Test-VpnAdapter $ciscoSample)) { throw 'Cisco AnyConnect adapter detection failed.' }
+    if (Test-VpnAdapter $ethernetSample) { throw 'Unrelated adapter detection failed.' }
+
+    # Synthetic process table: Code.exe root (1000) with a renderer
+    # (1001), an extension host (1002) that spawned a helper CLI (1003),
+    # plus an unrelated process (2000) that must never be included.
+    $fakeProcesses = @(
+        [pscustomobject]@{ ProcessId = 1000; ParentProcessId = 1; Name = 'Code.exe' }
+        [pscustomobject]@{ ProcessId = 1001; ParentProcessId = 1000; Name = 'Code.exe' }
+        [pscustomobject]@{ ProcessId = 1002; ParentProcessId = 1000; Name = 'Code.exe' }
+        [pscustomobject]@{ ProcessId = 1003; ParentProcessId = 1002; Name = 'claude.exe' }
+        [pscustomobject]@{ ProcessId = 2000; ParentProcessId = 1; Name = 'notepad.exe' }
+    )
+
+    $tree = @(Get-CodeProcessTree -ProcessList $fakeProcesses)
+    foreach ($expected in 1000, 1001, 1002, 1003) {
+        if ($tree -notcontains $expected) { throw "Process tree walk missed pid $expected." }
+    }
+    if ($tree -contains 2000) { throw 'Process tree walk included an unrelated process.' }
+    if ($tree -contains $PID) { throw 'Process tree walk included its own pid.' }
+
+    $null = Get-VpnStatus
+    $null = @(Get-CodeProcessTree)
+    $null = Get-VpnTunnelInterface
+    # Get-PublicIp is intentionally not exercised here: it depends on
+    # outbound network access, which self-test must not require.
+
+    Write-Host 'Code Watch Windows self-test passed.' -ForegroundColor Green
+}
+
+if ($SelfTest) {
+    Invoke-SelfTest
+    exit 0
+}
+
+if ($Daemon) {
+    $paused = $false
+    $pausedAt = 0
+    $publicIpCache = $null
+    $publicIpCounter = 0
+    $publicIpInterval = 15 # ~30s at the default 2s refresh, so we don't hammer the lookup service
+    try {
+        while ($true) {
+            $command = Get-DaemonCommand
+            if ($command -eq 'pause') {
+                Suspend-CodeTree | Out-Null
+                if (-not $paused) { $pausedAt = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds() }
+                $paused = $true
+            }
+            elseif ($command -eq 'resume') {
+                Resume-CodeTree
+                $paused = $false
+                $pausedAt = 0
+            }
+            elseif ($command -eq 'stop') {
+                break
+            }
+
+            $vpnStatus = Get-VpnStatus
+            $pids = @(Get-CodeProcessTree)
+            $tunnelIface = Get-VpnTunnelInterface
+
+            $publicIpCounter++
+            if (-not $publicIpCache -or $publicIpCounter -ge $publicIpInterval) {
+                $newIp = Get-PublicIp
+                if ($newIp) { $publicIpCache = $newIp }
+                $publicIpCounter = 0
+            }
+
+            if (-not $vpnStatus -and -not $paused -and $pids.Count -gt 0) {
+                Suspend-CodeTree | Out-Null
+                $pausedAt = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+                $paused = $true
+            }
+            elseif ($vpnStatus -and $paused) {
+                Resume-CodeTree
+                $paused = $false
+                $pausedAt = 0
+            }
+
+            Write-DaemonStatus -VpnState $(if ($vpnStatus) { 'connected' } else { 'disconnected' }) `
+                -Detail $vpnStatus -State $(if ($paused) { 'paused' } else { 'running' }) -ProcessCount $pids.Count `
+                -Iface $(if ($tunnelIface) { $tunnelIface } else { '' }) -IpAddress $(if ($publicIpCache) { $publicIpCache } else { '' }) `
+                -PausedAt $pausedAt
+
+            Start-Sleep -Seconds $RefreshSeconds
+        }
+    }
+    finally {
+        if ($paused) { Resume-CodeTree }
+    }
+    exit 0
+}
+
+$originalCursorVisible = [Console]::CursorVisible
+$exitRequested = $false
+$paused = $false
+$pausedAt = 0
+$publicIpCache = $null
+$publicIpCounter = 0
+$publicIpInterval = 15
+
+try {
+    [Console]::Clear()
+    [Console]::CursorVisible = $false
+
+    while (-not $exitRequested) {
+        $vpnStatus = Get-VpnStatus
+        $pids = @(Get-CodeProcessTree)
+        $tunnelIface = Get-VpnTunnelInterface
+
+        $publicIpCounter++
+        if (-not $publicIpCache -or $publicIpCounter -ge $publicIpInterval) {
+            $newIp = Get-PublicIp
+            if ($newIp) { $publicIpCache = $newIp }
+            $publicIpCounter = 0
+        }
+
+        if (-not $vpnStatus -and -not $paused -and $pids.Count -gt 0) {
+            Suspend-CodeTree | Out-Null
+            $pausedAt = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+            $paused = $true
+        }
+        elseif ($vpnStatus -and $paused) {
+            Resume-CodeTree
+            $paused = $false
+            $pausedAt = 0
+        }
+
+        Show-Status -ProcessCount $pids.Count -VpnStatus $vpnStatus -Paused $paused -TunnelIface $tunnelIface -PublicIp $publicIpCache -PausedAt $pausedAt
+
+        $deadline = (Get-Date).AddSeconds($RefreshSeconds)
+        :waitLoop while ((Get-Date) -lt $deadline) {
+            if ([Console]::KeyAvailable) {
+                $key = [Console]::ReadKey($true).Key
+                switch ($key) {
+                    'P' {
+                        Suspend-CodeTree | Out-Null
+                        $pausedAt = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+                        $paused = $true
+                        break waitLoop
+                    }
+                    'R' {
+                        Resume-CodeTree
+                        $paused = $false
+                        $pausedAt = 0
+                        break waitLoop
+                    }
+                    'X' {
+                        $exitRequested = $true
+                        break waitLoop
+                    }
+                    'Q' {
+                        $exitRequested = $true
+                        break waitLoop
+                    }
+                }
+            }
+
+            Start-Sleep -Milliseconds 100
+        }
+    }
+}
+finally {
+    if ($paused) {
+        Resume-CodeTree
+    }
+    [Console]::CursorVisible = $originalCursorVisible
+    Write-Host 'Monitor stopped.' -ForegroundColor Cyan
+}

--- a/code-watch.sh
+++ b/code-watch.sh
@@ -1,0 +1,311 @@
+#!/bin/bash
+
+# Suspend and resume the entire VS Code process tree based on VPN
+# connectivity on macOS. Unlike claude-watch.sh (which kills Claude
+# processes), this script freezes VS Code with SIGSTOP so no code,
+# extension, or integrated-terminal process under it can touch the
+# network while the VPN is down, then wakes it back up with SIGCONT
+# once the VPN returns. No windows or unsaved buffers are lost.
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+REFRESH_SECONDS=2
+SELF_PID=$$
+
+# Override to target VS Code Insiders, VSCodium, etc.
+APP_BUNDLE_NAME=${CODE_WATCH_APP_NAME:-"Visual Studio Code"}
+LAUNCHER_PATTERN="/${APP_BUNDLE_NAME}\.app/Contents/MacOS/Code$"
+
+# The public IP is what actually shows on the wire if something leaks, so
+# it matters more here than the tunnel's local address — but it needs a
+# real HTTP round trip, so it's only refreshed every PUBLIC_IP_INTERVAL
+# cycles (and cached in between) instead of on every loop tick.
+PUBLIC_IP_INTERVAL=15
+public_ip_cache=""
+public_ip_counter=0
+
+DAEMON_MODE=false
+STATUS_FILE=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --daemon)
+            DAEMON_MODE=true
+            STATUS_FILE="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+paused=false
+paused_at=0
+
+write_status() {
+    [[ -z "$STATUS_FILE" ]] && return
+    local tmp="${STATUS_FILE}.tmp.$$"
+    {
+        printf 'VPN=%s\n' "$1"
+        printf 'DETAIL=%s\n' "$2"
+        printf 'STATE=%s\n' "$3"
+        printf 'PIDS=%s\n' "$4"
+        printf 'IFACE=%s\n' "$5"
+        printf 'IP=%s\n' "$6"
+        printf 'PAUSED_AT=%s\n' "$7"
+        printf 'UPDATED=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    } > "$tmp" && mv "$tmp" "$STATUS_FILE"
+}
+
+resume_before_exit() {
+    if [[ "$paused" == true ]]; then
+        resume_code
+    fi
+}
+
+cleanup() {
+    resume_before_exit
+    if [[ "$DAEMON_MODE" == false ]]; then
+        printf '\033[?25h\033[?1049l%bMonitor stopped.%b\n' "$CYAN" "$RESET"
+        stty echo 2>/dev/null || true
+    fi
+    rm -f "${STATUS_FILE}.cmd" 2>/dev/null
+    exit 0
+}
+
+trap cleanup INT TERM HUP
+
+code_pids() {
+    # A single ps snapshot plus an in-awk BFS over the pid/ppid table.
+    # macOS's `pgrep -P` has been observed to silently drop real children
+    # under this app's process tree, which is unacceptable for a script
+    # that decides what to freeze — so the tree walk never shells out to
+    # pgrep per level.
+    ps -eo pid,ppid,comm | awk -v self="$SELF_PID" -v pat="$LAUNCHER_PATTERN" '
+        NR == 1 { next }
+        {
+            pid = $1
+            ppid = $2
+            comm = $0
+            sub(/^[ \t]*[0-9]+[ \t]+[0-9]+[ \t]+/, "", comm)
+            ppid_of[pid] = ppid
+            comm_of[pid] = comm
+            children[ppid] = children[ppid] " " pid
+            if (ppid == 1 && pid != self && comm ~ pat) {
+                roots[pid] = 1
+            }
+        }
+        END {
+            n = 0
+            for (r in roots) { queue[n++] = r; visited[r] = 1 }
+            for (i = 0; i < n; i++) {
+                p = queue[i]
+                if (p != self) print p
+                split(children[p], kids, " ")
+                for (k in kids) {
+                    c = kids[k]
+                    if (c != "" && !(c in visited)) {
+                        visited[c] = 1
+                        queue[n++] = c
+                    }
+                }
+            }
+        }
+    ' | sort -un
+}
+
+vpn_status() {
+    local connected_service nwi_interfaces routed_tunnels
+
+    connected_service=$(scutil --nc list 2>/dev/null |
+        sed -nE '/\(Connected\)/s/.*"([^"]+)".*/\1/p' |
+        paste -sd ',' - | sed 's/,/, /g')
+    if [[ -n "$connected_service" ]]; then
+        printf 'Connected: %s' "$connected_service"
+        return 0
+    fi
+
+    nwi_interfaces=$(scutil --nwi 2>/dev/null | awk '
+        /Network interfaces:/ {
+            for (i = 3; i <= NF; i++) {
+                gsub(/,/, "", $i)
+                if ($i ~ /^utun[0-9]+$/) print $i
+            }
+        }
+    ' | sort -u | paste -sd ',' - | sed 's/,/, /g')
+
+    if [[ -n "$nwi_interfaces" ]]; then
+        printf 'Connected (active tunnel: %s)' "$nwi_interfaces"
+        return 0
+    fi
+
+    # Cisco AnyConnect / OpenVPN-style clients may keep the normal default
+    # route while sending traffic through two half-default routes (0/1 and
+    # 128/1), the same pattern used by VyprVPN.
+    routed_tunnels=$(netstat -rn -f inet 2>/dev/null | awk '
+        /^Destination/ {
+            for (i = 1; i <= NF; i++)
+                if ($i == "Netif") interface_column = i
+            next
+        }
+        interface_column &&
+        ($1 == "default" || $1 == "0/1" || $1 == "0.0.0.0/1" ||
+         $1 == "128/1" || $1 == "128.0/1" || $1 == "128.0.0.0/1") &&
+        $interface_column ~ /^(utun|tun|tap|ppp|ipsec)[0-9]*$/ {
+            print $interface_column
+        }
+    ' | sort -u | paste -sd ',' - | sed 's/,/, /g')
+
+    if [[ -n "$routed_tunnels" ]]; then
+        printf 'Connected (routed tunnel: %s)' "$routed_tunnels"
+        return 0
+    fi
+
+    return 1
+}
+
+# First tunnel interface that actually carries an address, independent of
+# which detection method above flagged the VPN as connected.
+vpn_tunnel_iface() {
+    local iface ip
+    for iface in $(ifconfig -l 2>/dev/null | tr ' ' '\n' | grep -E '^(utun|tun|tap|ppp|ipsec)[0-9]*$'); do
+        ip=$(ifconfig "$iface" 2>/dev/null | awk '/inet /{print $2; exit}')
+        if [[ -n "$ip" ]]; then
+            printf '%s' "$iface"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# The externally-visible IP — what a leak would actually expose — tried
+# against a couple of providers in case one is blocked or down.
+fetch_public_ip() {
+    local ip
+    ip=$(curl -fsS --max-time 3 https://api.ipify.org 2>/dev/null) && [[ -n "$ip" ]] && { printf '%s' "$ip"; return 0; }
+    ip=$(curl -fsS --max-time 3 https://ifconfig.me/ip 2>/dev/null) && [[ -n "$ip" ]] && { printf '%s' "$ip"; return 0; }
+    ip=$(curl -fsS --max-time 3 https://icanhazip.com 2>/dev/null | tr -d '[:space:]') && [[ -n "$ip" ]] && { printf '%s' "$ip"; return 0; }
+    return 1
+}
+
+suspend_code() {
+    local pids
+    pids=$(code_pids)
+    [[ -z "$pids" ]] && return 1
+    while IFS= read -r pid; do
+        kill -STOP "$pid" 2>/dev/null || true
+    done <<< "$pids"
+    [[ "$paused" == false ]] && paused_at=$(date +%s)
+    paused=true
+    return 0
+}
+
+resume_code() {
+    local pids
+    pids=$(code_pids)
+    [[ -n "$pids" ]] && while IFS= read -r pid; do
+        kill -CONT "$pid" 2>/dev/null || true
+    done <<< "$pids"
+    paused=false
+    paused_at=0
+}
+
+check_command_file() {
+    [[ -z "$STATUS_FILE" || ! -f "${STATUS_FILE}.cmd" ]] && return
+    local cmd
+    cmd=$(<"${STATUS_FILE}.cmd")
+    rm -f "${STATUS_FILE}.cmd"
+    case "$cmd" in
+        pause) suspend_code ;;
+        resume) resume_code ;;
+        stop) cleanup ;;
+    esac
+}
+
+if [[ "$DAEMON_MODE" == false ]]; then
+    printf '\033[?1049h\033[2J\033[H\033[?25l'
+fi
+
+while true; do
+    check_command_file
+
+    vpn=''
+    vpn_connected=false
+    if vpn=$(vpn_status); then
+        vpn_connected=true
+    fi
+
+    pids=$(code_pids)
+    process_count=0
+    [[ -n "$pids" ]] && process_count=$(printf '%s\n' "$pids" | wc -l | tr -d ' ')
+
+    iface=$(vpn_tunnel_iface) || iface=''
+
+    public_ip_counter=$((public_ip_counter + 1))
+    if [[ -z "$public_ip_cache" || "$public_ip_counter" -ge "$PUBLIC_IP_INTERVAL" ]]; then
+        if new_ip=$(fetch_public_ip); then
+            public_ip_cache="$new_ip"
+        fi
+        public_ip_counter=0
+    fi
+
+    if [[ "$vpn_connected" == false && "$paused" == false && -n "$pids" ]]; then
+        suspend_code
+    elif [[ "$vpn_connected" == true && "$paused" == true ]]; then
+        resume_code
+    fi
+
+    state='running'
+    [[ "$paused" == true ]] && state='paused'
+
+    if [[ "$DAEMON_MODE" == true ]]; then
+        write_status "$([[ "$vpn_connected" == true ]] && echo connected || echo disconnected)" "$vpn" "$state" "$process_count" "$iface" "$public_ip_cache" "$paused_at"
+        sleep "$REFRESH_SECONDS"
+        continue
+    fi
+
+    printf '\033[H'
+    printf '\033[2K%b\n' "${BOLD}${CYAN}macOS VS Code + VPN Monitor${RESET}"
+    printf '\033[2KUpdated: %s  |  Refresh: %ss\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$REFRESH_SECONDS"
+    printf '\033[2K\n'
+
+    if [[ "$paused" == true ]]; then
+        elapsed=$(( $(date +%s) - paused_at ))
+        printf '\033[2K%b\n' "${RED}${BOLD}VS CODE IS PAUSED (${process_count} processes frozen, ${elapsed}s so far)${RESET}"
+    elif [[ -n "$pids" ]]; then
+        color=$([[ "$vpn_connected" == true ]] && echo "$GREEN" || echo "$YELLOW")
+        printf '\033[2K%b\n' "${color}${BOLD}VS Code running: ${process_count} processes${RESET}"
+    else
+        printf '\033[2K%b\n' "${GREEN}No VS Code processes detected.${RESET}"
+    fi
+
+    printf '\033[2K\n'
+    if [[ "$vpn_connected" == true ]]; then
+        printf '\033[2K%b\n' "${GREEN}${BOLD}VPN: ${vpn}${RESET}"
+    else
+        printf '\033[2K%b\n' "${RED}${BOLD}VPN: Not connected — VS Code auto-pause is armed${RESET}"
+    fi
+
+    printf '\033[2KTunnel interface: %s\n' "${iface:-none}"
+    printf '\033[2KPublic IP: %s\n' "${public_ip_cache:-unknown}"
+
+    printf '\033[2K\n'
+    printf '\033[2K%s\n' 'Options: [p] Pause now   [r] Resume now   [x] Exit'
+    printf '\033[2K%s' 'Choice (monitor keeps refreshing): '
+    printf '\033[J'
+
+    choice=''
+    if IFS= read -r -s -n 1 -t "$REFRESH_SECONDS" choice; then
+        case "$choice" in
+            p|P) suspend_code ;;
+            r|R) resume_code ;;
+            x|X|q|Q) cleanup ;;
+        esac
+    fi
+done

--- a/vscode-extension/.gitignore
+++ b/vscode-extension/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+out/
+scripts/
+*.vsix

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial release: detached watcher daemon, Activity Bar status dashboard with badge, optional status-bar indicator, start/stop/pause/resume commands.

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -1,0 +1,36 @@
+# Code Watch (VPN Kill-Switch)
+
+Freezes the entire VS Code process tree — the editor, every helper process, and anything an extension spawned under it (language servers, integrated-terminal shells, CLIs) — the instant your VPN disconnects, and resumes automatically once it reconnects. No windows or unsaved buffers are lost; VS Code is simply unresponsive while paused.
+
+Built for Cisco AnyConnect and similar corporate VPN setups where nothing under the editor should be able to reach the network outside the tunnel.
+
+## What you get
+
+- A dedicated **Code Watch** icon in the Activity Bar with a status dashboard: VPN state, tunnel interface, IP address, frozen-process count, and last check time.
+- A red badge on that icon whenever VS Code is actually paused — visible at a glance, no click required.
+- An optional status-bar indicator (enable via `View: Toggle Status Bar Visibility` if you keep your status bar hidden).
+- Commands to start/stop monitoring or pause/resume manually.
+
+## Commands
+
+| Command | What it does |
+|---|---|
+| `Code Watch: Start Monitoring` | Launches the background watcher daemon. |
+| `Code Watch: Stop Monitoring` | Ends the daemon (resumes VS Code first if it was paused). |
+| `Code Watch: Pause VS Code Now` | Manually freezes VS Code, without waiting for a VPN drop. |
+| `Code Watch: Resume VS Code Now` | Manually resumes a paused VS Code. |
+
+## Settings
+
+- `codeWatch.autoStart` (default `true`) — start the watcher automatically on launch.
+- `codeWatch.appProcessName` — override which app/process to watch (for VS Code Insiders, VSCodium, etc.).
+
+## How it works
+
+On activation, the extension spawns a small detached daemon (`code-watch.sh` on macOS, `code-watch.ps1` on Windows — the same scripts from the parent [claude-watch](https://github.com/omidkorat/claude-watch) project) that runs independently of VS Code's own process. It polls VPN connectivity every couple of seconds; when the VPN drops it walks the full VS Code process tree and sends `SIGSTOP` (macOS) / `NtSuspendProcess` (Windows) to every process in it, then `SIGCONT` / `NtResumeProcess` once the VPN is back.
+
+Because the daemon is detached and independent, it keeps working — and keeps watching — even while VS Code itself is frozen.
+
+## Warning
+
+Pausing the whole process tree also freezes anything running inside VS Code, including integrated terminals and other extensions (e.g. an AI coding assistant's CLI session). That's the point: nothing under the editor should be able to touch the network while the VPN is down.

--- a/vscode-extension/build-scripts/copy-watchers.js
+++ b/vscode-extension/build-scripts/copy-watchers.js
@@ -1,0 +1,16 @@
+// Keeps the extension's bundled watcher scripts in sync with the
+// standalone scripts at the repo root, so there is one source of truth
+// for the VPN-detection and suspend/resume logic.
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const targetDir = path.join(__dirname, '..', 'scripts');
+
+fs.mkdirSync(targetDir, { recursive: true });
+
+for (const name of ['code-watch.sh', 'code-watch.ps1']) {
+  fs.copyFileSync(path.join(repoRoot, name), path.join(targetDir, name));
+}
+
+console.log('Copied watcher scripts into vscode-extension/scripts/');

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,0 +1,59 @@
+{
+  "name": "code-watch",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "code-watch",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@types/vscode": "^1.85.0",
+        "typescript": "^5.4.0"
+      },
+      "engines": {
+        "vscode": "^1.85.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.125.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
+      "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,0 +1,92 @@
+{
+  "name": "code-watch",
+  "displayName": "Code Watch (VPN Kill-Switch)",
+  "description": "Freezes the entire VS Code process tree the instant your VPN drops, and resumes automatically once it reconnects — a kill-switch so no extension, terminal, or CLI under VS Code can leak traffic outside the tunnel.",
+  "version": "0.1.0",
+  "publisher": "masniper",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/omidkorat/claude-watch.git"
+  },
+  "keywords": [
+    "vpn",
+    "kill-switch",
+    "cisco anyconnect",
+    "security",
+    "network"
+  ],
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onStartupFinished"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "codeWatch.start",
+        "title": "Code Watch: Start Monitoring"
+      },
+      {
+        "command": "codeWatch.stop",
+        "title": "Code Watch: Stop Monitoring"
+      },
+      {
+        "command": "codeWatch.pauseNow",
+        "title": "Code Watch: Pause VS Code Now"
+      },
+      {
+        "command": "codeWatch.resumeNow",
+        "title": "Code Watch: Resume VS Code Now"
+      }
+    ],
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "codeWatch",
+          "title": "Code Watch",
+          "icon": "resources/icon.svg"
+        }
+      ]
+    },
+    "views": {
+      "codeWatch": [
+        {
+          "id": "codeWatch.statusView",
+          "name": "Status",
+          "icon": "resources/icon.svg"
+        }
+      ]
+    },
+    "configuration": {
+      "title": "Code Watch",
+      "properties": {
+        "codeWatch.autoStart": {
+          "type": "boolean",
+          "default": true,
+          "description": "Start the VPN watcher automatically when VS Code launches."
+        },
+        "codeWatch.appProcessName": {
+          "type": "string",
+          "default": "",
+          "description": "Override the app to watch: the .app bundle name without extension on macOS (e.g. 'Visual Studio Code - Insiders', 'VSCodium'), or the process name without .exe on Windows (e.g. 'Code - Insiders', 'VSCodium'). Leave empty for the stable VS Code default."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run build",
+    "build": "node ./build-scripts/copy-watchers.js && tsc -p ./",
+    "watch": "tsc -watch -p ./"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/vscode": "^1.85.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/vscode-extension/resources/icon.svg
+++ b/vscode-extension/resources/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <path d="M12 2L4 5v6c0 5.25 3.4 9.74 8 11 4.6-1.26 8-5.75 8-11V5l-8-3z" fill="#000000"/>
+</svg>

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,0 +1,262 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import { spawn } from 'child_process';
+
+const REFRESH_SECONDS = 2;
+const STALE_AFTER_MS = REFRESH_SECONDS * 1000 * 4;
+
+let statusBarItem: vscode.StatusBarItem;
+let sidebarProvider: CodeWatchStatusProvider;
+let sidebarView: vscode.TreeView<vscode.TreeItem>;
+let pollHandle: ReturnType<typeof setInterval> | undefined;
+let statusFile: string;
+let cmdFile: string;
+
+class CodeWatchStatusProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
+  private readonly emitter = new vscode.EventEmitter<void>();
+  readonly onDidChangeTreeData = this.emitter.event;
+
+  refresh(): void {
+    this.emitter.fire();
+  }
+
+  getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
+    return element;
+  }
+
+  getChildren(): vscode.TreeItem[] {
+    const status = readStatus();
+
+    if (!status) {
+      const starting = new vscode.TreeItem('Starting…');
+      starting.iconPath = new vscode.ThemeIcon('sync~spin');
+      return [starting];
+    }
+
+    const paused = status.STATE === 'paused';
+    const connected = status.VPN === 'connected';
+
+    const headline = new vscode.TreeItem(
+      paused ? 'VS Code: PAUSED' : connected ? 'VS Code: Protected' : 'VS Code: VPN down',
+    );
+    headline.iconPath = new vscode.ThemeIcon('circle-large-filled', paused || !connected ? RED : GREEN);
+    headline.command = { command: 'codeWatch.resumeNow', title: 'Resume Now' };
+    headline.tooltip = paused
+      ? 'VS Code is frozen because the VPN is disconnected.\nClick to resume manually once you are back on VPN.'
+      : connected
+        ? 'VPN connected. VS Code runs normally.'
+        : 'VPN disconnected. VS Code will be paused automatically.';
+
+    const vpnRow = new vscode.TreeItem('VPN');
+    vpnRow.description = connected ? (status.DETAIL || 'connected') : 'disconnected';
+    vpnRow.iconPath = new vscode.ThemeIcon(connected ? 'shield' : 'warning');
+
+    const ifaceRow = new vscode.TreeItem('Tunnel Interface');
+    ifaceRow.description = status.IFACE || '—';
+    ifaceRow.iconPath = new vscode.ThemeIcon('plug');
+
+    const ipRow = new vscode.TreeItem('Public IP');
+    ipRow.description = status.IP || 'checking…';
+    ipRow.tooltip = 'The externally-visible IP address — what a leak would actually expose. Refreshed roughly every 30s.';
+    ipRow.iconPath = new vscode.ThemeIcon('globe');
+
+    const processRow = new vscode.TreeItem('Frozen processes');
+    processRow.description = paused ? (status.PIDS || '0') : '0';
+    processRow.iconPath = new vscode.ThemeIcon(paused ? 'debug-pause' : 'debug-start');
+
+    const updatedRow = new vscode.TreeItem('Last check');
+    updatedRow.description = formatLocalTime(status.UPDATED);
+    updatedRow.iconPath = new vscode.ThemeIcon('clock');
+
+    const rows = [headline, vpnRow, ifaceRow, ipRow, processRow, updatedRow];
+
+    if (paused && status.PAUSED_AT) {
+      const pausedAtMs = Number(status.PAUSED_AT) * 1000;
+      if (!Number.isNaN(pausedAtMs) && pausedAtMs > 0) {
+        const elapsedRow = new vscode.TreeItem('Frozen for');
+        elapsedRow.description = `${Math.max(0, Math.round((Date.now() - pausedAtMs) / 1000))}s (as of last check)`;
+        elapsedRow.tooltip = 'This number only advances on each poll — it cannot tick live while VS Code itself is frozen.';
+        elapsedRow.iconPath = new vscode.ThemeIcon('watch');
+        rows.push(elapsedRow);
+      }
+    }
+
+    return rows;
+  }
+}
+
+function formatLocalTime(iso?: string): string {
+  if (!iso) { return '—'; }
+  const parsed = new Date(iso);
+  return Number.isNaN(parsed.getTime()) ? '—' : parsed.toLocaleTimeString();
+}
+
+function scriptPathsFor(extensionPath: string): { command: string; args: string[]; env?: NodeJS.ProcessEnv } | undefined {
+  const appName = vscode.workspace.getConfiguration('codeWatch').get<string>('appProcessName', '').trim();
+
+  if (process.platform === 'darwin') {
+    const script = path.join(extensionPath, 'scripts', 'code-watch.sh');
+    const env = appName ? { ...process.env, CODE_WATCH_APP_NAME: appName } : process.env;
+    return { command: '/bin/bash', args: [script, '--daemon', statusFile], env };
+  }
+
+  if (process.platform === 'win32') {
+    const script = path.join(extensionPath, 'scripts', 'code-watch.ps1');
+    return {
+      command: 'powershell.exe',
+      args: [
+        '-NoProfile',
+        '-ExecutionPolicy', 'Bypass',
+        '-File', script,
+        '-Daemon',
+        '-StatusFile', statusFile,
+        '-AppProcessName', appName || 'Code',
+      ],
+    };
+  }
+
+  return undefined;
+}
+
+function readStatus(): Record<string, string> | undefined {
+  try {
+    const raw = fs.readFileSync(statusFile, 'utf8');
+    const status: Record<string, string> = {};
+    for (const line of raw.split('\n')) {
+      const idx = line.indexOf('=');
+      if (idx === -1) { continue; }
+      status[line.slice(0, idx).trim()] = line.slice(idx + 1).trim();
+    }
+    return status;
+  } catch {
+    return undefined;
+  }
+}
+
+function isDaemonAlive(): boolean {
+  const status = readStatus();
+  if (!status?.UPDATED) { return false; }
+  const updated = Date.parse(status.UPDATED);
+  return !Number.isNaN(updated) && Date.now() - updated < STALE_AFTER_MS;
+}
+
+function writeCommand(cmd: 'pause' | 'resume' | 'stop'): void {
+  fs.writeFileSync(cmdFile, cmd, 'utf8');
+}
+
+function startWatcher(extensionPath: string): void {
+  if (isDaemonAlive()) {
+    updateStatusBar();
+    return;
+  }
+
+  const target = scriptPathsFor(extensionPath);
+  if (!target) {
+    statusBarItem.text = '$(warning) Code Watch: unsupported OS';
+    statusBarItem.show();
+    return;
+  }
+
+  const child = spawn(target.command, target.args, {
+    detached: true,
+    stdio: 'ignore',
+    windowsHide: true,
+    env: target.env,
+  });
+  child.unref();
+}
+
+const GREEN = new vscode.ThemeColor('terminal.ansiGreen');
+const RED = new vscode.ThemeColor('terminal.ansiRed');
+
+// VS Code's own UI (this extension included) is frozen along with
+// everything else while paused, so there is no way to show a live
+// countdown during the freeze — the best we can do is remember when it
+// started and report the total once the extension host is running again.
+let localPauseStartedAt: number | undefined;
+
+function updateStatusBar(): void {
+  const status = readStatus();
+  if (!status) {
+    statusBarItem.text = '$(sync~spin) Code Watch: starting…';
+    statusBarItem.color = undefined;
+    statusBarItem.backgroundColor = undefined;
+    statusBarItem.show();
+    return;
+  }
+
+  const paused = status.STATE === 'paused';
+  const connected = status.VPN === 'connected';
+
+  if (paused && localPauseStartedAt === undefined) {
+    localPauseStartedAt = Date.now();
+  } else if (!paused && localPauseStartedAt !== undefined) {
+    const elapsedSec = Math.round((Date.now() - localPauseStartedAt) / 1000);
+    localPauseStartedAt = undefined;
+    vscode.window.showInformationMessage(`Code Watch: VS Code was frozen for ${elapsedSec}s while the VPN was disconnected.`);
+  }
+
+  if (paused) {
+    statusBarItem.text = `$(debug-pause) Code Watch: PAUSED (${status.PIDS ?? '?'} procs)`;
+    statusBarItem.color = RED;
+    statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
+    statusBarItem.tooltip = 'VS Code is frozen because the VPN is disconnected.\nClick to resume manually once you are back on VPN.';
+  } else if (!connected) {
+    statusBarItem.text = '$(shield) Code Watch: VPN down, armed';
+    statusBarItem.color = RED;
+    statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
+    statusBarItem.tooltip = 'VPN disconnected. VS Code will be paused automatically.';
+  } else {
+    statusBarItem.text = `$(shield) Code Watch: ${status.DETAIL ?? 'connected'}`;
+    statusBarItem.color = GREEN;
+    statusBarItem.backgroundColor = undefined;
+    statusBarItem.tooltip = 'VPN connected. VS Code runs normally.';
+  }
+  statusBarItem.show();
+  sidebarProvider?.refresh();
+
+  if (sidebarView) {
+    sidebarView.badge = paused
+      ? { value: Number(status.PIDS) || 1, tooltip: 'VS Code is paused — VPN disconnected' }
+      : undefined;
+  }
+}
+
+export function activate(context: vscode.ExtensionContext): void {
+  const storageDir = context.globalStorageUri.fsPath;
+  fs.mkdirSync(storageDir, { recursive: true });
+  statusFile = path.join(storageDir, 'code-watch.status');
+  cmdFile = `${statusFile}.cmd`;
+
+  statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 1_000_000);
+  statusBarItem.command = 'codeWatch.resumeNow';
+  context.subscriptions.push(statusBarItem);
+
+  sidebarProvider = new CodeWatchStatusProvider();
+  sidebarView = vscode.window.createTreeView('codeWatch.statusView', { treeDataProvider: sidebarProvider });
+  context.subscriptions.push(sidebarView);
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('codeWatch.start', () => startWatcher(context.extensionPath)),
+    vscode.commands.registerCommand('codeWatch.stop', () => writeCommand('stop')),
+    vscode.commands.registerCommand('codeWatch.pauseNow', () => writeCommand('pause')),
+    vscode.commands.registerCommand('codeWatch.resumeNow', () => writeCommand('resume')),
+  );
+
+  pollHandle = setInterval(updateStatusBar, REFRESH_SECONDS * 1000);
+  context.subscriptions.push({ dispose: () => pollHandle && clearInterval(pollHandle) });
+
+  const autoStart = vscode.workspace.getConfiguration('codeWatch').get<boolean>('autoStart', true);
+  if (autoStart) {
+    startWatcher(context.extensionPath);
+  }
+  updateStatusBar();
+}
+
+export function deactivate(): void {
+  // Intentionally leave the detached watcher daemon running: it must
+  // keep monitoring the VPN even while VS Code itself is closed or
+  // paused. Use the "Code Watch: Stop Monitoring" command to end it
+  // explicitly (e.g. before uninstalling).
+}

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "outDir": "out",
+    "rootDir": "src",
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "exclude": ["node_modules", ".vscode-test"]
+}


### PR DESCRIPTION
## Summary

Adds a second kill-switch alongside `claude-watch`, aimed at a different failure mode: instead of killing Claude processes when the VPN drops, this **freezes VS Code itself** so nothing running under it — extensions, integrated-terminal shells, language servers, CLIs — can reach the network outside the tunnel while disconnected.

- `code-watch.sh` (macOS) / `code-watch.ps1` (Windows): same VPN detection as `claude-watch`, but suspends (`SIGSTOP`/`NtSuspendProcess`) the *entire* VS Code process tree on disconnect and resumes (`SIGCONT`/`NtResumeProcess`) it on reconnect. No windows or unsaved buffers are lost — VS Code is just unresponsive while paused.
- The process tree is walked from a single `ps`/CIM snapshot rather than per-level `pgrep -P`/parent lookups. `pgrep -P` was observed (on current macOS) to silently drop a real child under VS Code's tree during testing — not acceptable for a script deciding what to freeze.
- Both scripts support a `--daemon`/`-Daemon` headless mode with a status file and a `pause`/`resume`/`stop` command file, so something else (like the extension) can drive them.
- `vscode-extension/`: wraps the script as a VS Code extension so the kill-switch is armed automatically every time VS Code opens. Status shows in a dedicated Activity Bar view (VPN state, tunnel interface, public IP, frozen-process count, last check), with a badge that only appears while actually paused.

## Why a separate script instead of extending claude-watch.sh

Different target (VS Code's own process tree vs. anything named `claude`) and different action (suspend/resume vs. kill), so I kept it as sibling scripts rather than overloading the existing one with a mode flag. Happy to restructure if you'd prefer one script with a `--target` option instead.

## Notes / things worth double-checking

- **macOS**: tested directly against a live VS Code process tree, including confirming the tree walk correctly reaches processes an extension spawned (verified with a real extension's child process), and that the daemon correctly excludes its own PID from the suspend set.
- **Windows**: `code-watch.ps1` is *not* verified on a real Windows machine — I don't have one available. The self-test (`-SelfTest`) covers the process-tree logic with a synthetic table and the VPN-adapter regex (including Cisco AnyConnect), and CI now runs it, but the `NtSuspendProcess`/`NtResumeProcess` P/Invoke path itself needs a real run to confirm.
- The extension is a manual/sideloaded build for now (not published to the Marketplace) — `cd vscode-extension && npm install && npm run build`, then run via Extension Development Host or `vsce package`.
- Pausing the whole tree is intentional but worth calling out explicitly: it also freezes other extensions and integrated terminals, not just network access. Documented as a warning in both READMEs.

## Test plan

- [x] `bash -n code-watch.sh` — syntax check
- [x] Manual verification of VPN detection (service/tunnel/routed-route paths) against a live Cisco AnyConnect connection
- [x] Manual verification of process-tree walk against a live VS Code instance (including nested extension-spawned processes)
- [x] `code-watch.ps1 -SelfTest` reviewed and added to CI (not yet run — no Windows machine on hand)
- [ ] Real end-to-end run on Windows
- [ ] Extension smoke-tested manually in a real VS Code window (Activity Bar view, badge, pause/resume commands, public IP display)