### PR TITLE
Add VPN-aware time zone safety

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,4 +1,4 @@
-name: Windows compatibility
+name: Compatibility
 
 on:
   push:
@@ -10,6 +10,17 @@ permissions:
   contents: read
 
 jobs:
+  macos-bash:
+    runs-on: macos-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Validate and self-test macOS Bash script
+        run: |
+          bash -n ./claude-watch.sh
+          bash ./claude-watch.sh --self-test
+
   windows-powershell:
     runs-on: windows-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # Claude Watch
 
-Claude Watch is a lightweight, interactive macOS and Windows terminal monitor for Claude processes and VPN connectivity.
+Claude Watch is a lightweight, interactive macOS and Windows terminal monitor for Claude processes, VPN connectivity, and safe time-zone switching.
 
 ## Features
 
 - Refreshes every two seconds without filling Terminal scrollback.
-- Shows the number of running processes whose command contains `claude`.
+- Shows the number of running Claude processes using process-name matching.
 - Detects system-managed VPNs and common third-party VPN adapters.
-- Automatically stops every matching Claude process when no VPN is detected.
+- Allows Claude only when a VPN is connected and the time zone is New York.
+- Automatically switches to New York time while the VPN is connected and Tehran time when it disconnects.
+- Automatically stops every matching Claude process when either safety condition is not met.
 - Lets you manually stop all matching processes by pressing `k`.
 - Exits cleanly with `x`, `q`, or `Control-C`.
 
 > [!WARNING]
-> Claude Watch intentionally terminates processes automatically whenever its VPN checks report no connection. Because matching is case-insensitive and command-line based, it may also stop other processes whose command contains `claude`.
+> Claude Watch intentionally terminates Claude processes whenever its VPN or time-zone safety checks fail. Changing the system time zone requires macOS administrator authentication or Windows UAC approval.
 
 ## macOS
 
@@ -42,13 +44,25 @@ The execution-policy option applies only to that invocation and does not change 
 ## Controls
 
 - Press `k` to stop every detected Claude process.
+- Press `t` to retry synchronizing the time zone with the VPN state.
 - Press `x` or `q` to exit.
 
 ## Status colors
 
-- Green: VPN connected, or no Claude processes detected.
-- Yellow: Claude is running while a VPN is connected.
-- Red: VPN disconnected, auto-kill armed, or an automatic stop was triggered.
+- Green: a system condition is correctly synchronized.
+- Yellow: Claude is running while both VPN and New York time are confirmed.
+- Red: Claude is blocked, a safety condition failed, or an automatic stop was triggered.
+
+## Time-zone safety
+
+Claude Watch keeps the system in one of two explicit states:
+
+| VPN | Required time zone | Claude |
+| --- | --- | --- |
+| Connected | New York (`America/New_York` on macOS; `Eastern Standard Time` on Windows) | Allowed |
+| Disconnected | Tehran (`Asia/Tehran` on macOS; `Iran Standard Time` on Windows) | Blocked |
+
+Claude is stopped before an inconsistent time zone is corrected. If administrator authorization is declined or the change cannot be verified, Claude remains blocked and the monitor offers a manual retry with `t`.
 
 ## VPN detection on macOS
 

--- a/claude-watch.ps1
+++ b/claude-watch.ps1
@@ -6,6 +6,8 @@ param(
 )
 
 $RefreshSeconds = 2
+$RequiredTimeZone = 'Eastern Standard Time'
+$HomeTimeZone = 'Iran Standard Time'
 $VpnAdapterPattern = '(?i)(vpn|wireguard|wintun|openvpn|tailscale|nordlynx|proton|mullvad|anyconnect|globalprotect|fortinet|tap[-_ ]|tun[-_ ])'
 
 function Test-ClaudeProcess {
@@ -18,8 +20,8 @@ function Test-ClaudeProcess {
         return $false
     }
 
-    return (([string]$Process.Name -match '(?i)claude') -or
-        ([string]$Process.CommandLine -match '(?i)claude'))
+    $processName = [IO.Path]::GetFileNameWithoutExtension([string]$Process.Name)
+    return ($processName -match '(?i)^claude($|[ -])')
 }
 
 function Get-ClaudeProcesses {
@@ -29,7 +31,7 @@ function Get-ClaudeProcesses {
     }
     catch {
         return @(Get-Process -ErrorAction SilentlyContinue |
-            Where-Object { $_.Id -ne $PID -and $_.ProcessName -match '(?i)claude' } |
+            Where-Object { $_.Id -ne $PID -and $_.ProcessName -match '(?i)^claude($|[ -])' } |
             ForEach-Object {
                 [pscustomobject]@{
                     ProcessId  = $_.Id
@@ -37,6 +39,48 @@ function Get-ClaudeProcesses {
                     CommandLine = $null
                 }
             })
+    }
+}
+
+function Get-TargetTimeZone {
+    param([AllowNull()][string]$VpnStatus)
+
+    if ($VpnStatus) {
+        return $RequiredTimeZone
+    }
+
+    return $HomeTimeZone
+}
+
+function Set-ClaudeWatchTimeZone {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$TimeZoneId
+    )
+
+    try {
+        $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+        $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+        $isAdministrator = $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+        if ($isAdministrator) {
+            Set-TimeZone -Id $TimeZoneId -ErrorAction Stop
+        }
+        else {
+            $escapedId = $TimeZoneId.Replace("'", "''")
+            $command = "Set-TimeZone -Id '$escapedId' -ErrorAction Stop"
+            $encodedCommand = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($command))
+            $process = Start-Process -FilePath powershell.exe -Verb RunAs -Wait -PassThru `
+                -ArgumentList "-NoProfile -EncodedCommand $encodedCommand" -ErrorAction Stop
+            if ($process.ExitCode -ne 0) {
+                return $false
+            }
+        }
+
+        return ((Get-TimeZone -ErrorAction Stop).Id -eq $TimeZoneId)
+    }
+    catch {
+        return $false
     }
 }
 
@@ -130,7 +174,13 @@ function Show-Status {
     param(
         [object[]]$ClaudeProcesses,
         [string]$VpnStatus,
-        [bool]$AutoKilled
+        [bool]$AutoKilled,
+        [string]$AutoKillReason,
+        [string]$CurrentTimeZone,
+        [string]$TargetTimeZone,
+        [bool]$TimeZoneSynced,
+        [bool]$TimeZoneChangeFailed,
+        [string]$TimeZoneChangedTo
     )
 
     [Console]::SetCursorPosition(0, 0)
@@ -141,7 +191,7 @@ function Show-Status {
     if ($ClaudeProcesses.Count -eq 0) {
         Write-StatusLine 'No Claude processes are running.' Green
     }
-    elseif ($VpnStatus) {
+    elseif ($VpnStatus -and $CurrentTimeZone -eq $RequiredTimeZone) {
         Write-StatusLine ('CLAUDE IS RUNNING: {0} process(es)' -f $ClaudeProcesses.Count) Yellow
     }
     else {
@@ -149,7 +199,7 @@ function Show-Status {
     }
 
     if ($AutoKilled) {
-        Write-StatusLine 'Claude was automatically stopped because the VPN is disconnected.' Red
+        Write-StatusLine ('Claude was automatically stopped because {0}.' -f $AutoKillReason) Red
     }
     else {
         Write-StatusLine ''
@@ -164,7 +214,33 @@ function Show-Status {
     }
 
     Write-StatusLine ''
-    Write-StatusLine 'Options: [K] Kill all Claude processes   [X] Exit'
+    if ($TimeZoneSynced) {
+        Write-StatusLine ('TIME ZONE: {0}' -f $CurrentTimeZone) Green
+    }
+    else {
+        Write-StatusLine ('TIME ZONE: {0} - expected {1}' -f $CurrentTimeZone, $TargetTimeZone) Red
+    }
+
+    if ($VpnStatus -and $CurrentTimeZone -eq $RequiredTimeZone) {
+        if ($TimeZoneChangedTo -eq $RequiredTimeZone) {
+            Write-StatusLine 'READY: Time zone changed to New York. You can open Claude now.' Green
+        }
+        else {
+            Write-StatusLine 'READY: VPN and New York time zone confirmed. You can open Claude.' Green
+        }
+    }
+    elseif (-not $VpnStatus -and $TimeZoneSynced) {
+        Write-StatusLine 'SAFE: Time zone is Tehran. Claude remains blocked until VPN connects.' Red
+    }
+    elseif ($TimeZoneChangeFailed) {
+        Write-StatusLine 'Time zone change failed. Claude remains blocked; press [T] to retry.' Red
+    }
+    else {
+        Write-StatusLine ''
+    }
+
+    Write-StatusLine ''
+    Write-StatusLine 'Options: [K] Kill Claude   [T] Sync time zone   [X] Exit'
     Write-StatusLine 'Monitor keeps refreshing automatically.'
 }
 
@@ -178,6 +254,11 @@ function Invoke-SelfTest {
         ProcessId  = 10002
         Name       = 'node.exe'
         CommandLine = 'node.exe C:\tools\claude-helper.js'
+    }
+    $helperSample = [pscustomobject]@{
+        ProcessId  = 10004
+        Name       = 'Claude Helper.exe'
+        CommandLine = 'C:\Program Files\Claude\Claude Helper.exe'
     }
     $otherSample = [pscustomobject]@{
         ProcessId  = 10003
@@ -194,10 +275,15 @@ function Invoke-SelfTest {
     }
 
     if (-not (Test-ClaudeProcess $claudeSample)) { throw 'Claude name detection failed.' }
-    if (-not (Test-ClaudeProcess $commandSample)) { throw 'Claude command-line detection failed.' }
+    if (Test-ClaudeProcess $commandSample) { throw 'Command-line false-positive rejection failed.' }
+    if (-not (Test-ClaudeProcess $helperSample)) { throw 'Claude helper detection failed.' }
     if (Test-ClaudeProcess $otherSample) { throw 'Unrelated process detection failed.' }
     if (-not (Test-VpnAdapter $vpnSample)) { throw 'VPN adapter detection failed.' }
     if (Test-VpnAdapter $ethernetSample) { throw 'Unrelated adapter detection failed.' }
+    if ((Get-TargetTimeZone 'Connected: Test VPN') -ne $RequiredTimeZone) { throw 'VPN time-zone target failed.' }
+    if ((Get-TargetTimeZone $null) -ne $HomeTimeZone) { throw 'Disconnected time-zone target failed.' }
+    if (-not (Get-TimeZone -ListAvailable | Where-Object { $_.Id -eq $RequiredTimeZone })) { throw 'New York time-zone ID is unavailable.' }
+    if (-not (Get-TimeZone -ListAvailable | Where-Object { $_.Id -eq $HomeTimeZone })) { throw 'Tehran time-zone ID is unavailable.' }
 
     $null = @(Get-ClaudeProcesses)
     $null = Get-VpnStatus
@@ -211,6 +297,9 @@ if ($SelfTest) {
 
 $originalCursorVisible = [Console]::CursorVisible
 $exitRequested = $false
+$timeZoneAttemptedFor = $null
+$timeZoneChangedTo = $null
+$timeZoneChangeFailed = $false
 
 try {
     [Console]::Clear()
@@ -220,14 +309,47 @@ try {
         $claudeProcesses = @(Get-ClaudeProcesses)
         $vpnStatus = Get-VpnStatus
         $autoKilled = $false
+        $autoKillReason = $null
+        $currentTimeZone = (Get-TimeZone).Id
+        $targetTimeZone = Get-TargetTimeZone $vpnStatus
+        $timeZoneSynced = ($currentTimeZone -eq $targetTimeZone)
 
-        if ($claudeProcesses.Count -gt 0 -and -not $vpnStatus) {
+        if ($timeZoneSynced) {
+            $timeZoneAttemptedFor = $null
+            $timeZoneChangeFailed = $false
+        }
+
+        if ($claudeProcesses.Count -gt 0 -and
+            ((-not $vpnStatus) -or $currentTimeZone -ne $RequiredTimeZone)) {
             Stop-ClaudeProcesses
             $autoKilled = $true
+            if (-not $vpnStatus) {
+                $autoKillReason = 'the VPN is disconnected'
+            }
+            else {
+                $autoKillReason = "the time zone is $currentTimeZone, not $RequiredTimeZone"
+            }
             $claudeProcesses = @(Get-ClaudeProcesses)
         }
 
-        Show-Status -ClaudeProcesses $claudeProcesses -VpnStatus $vpnStatus -AutoKilled $autoKilled
+        if (-not $timeZoneSynced -and $timeZoneAttemptedFor -ne $targetTimeZone) {
+            $timeZoneAttemptedFor = $targetTimeZone
+            if (Set-ClaudeWatchTimeZone $targetTimeZone) {
+                $currentTimeZone = (Get-TimeZone).Id
+                $timeZoneSynced = $true
+                $timeZoneChangedTo = $targetTimeZone
+                $timeZoneChangeFailed = $false
+            }
+            else {
+                $currentTimeZone = (Get-TimeZone).Id
+                $timeZoneChangeFailed = $true
+            }
+        }
+
+        Show-Status -ClaudeProcesses $claudeProcesses -VpnStatus $vpnStatus -AutoKilled $autoKilled `
+            -AutoKillReason $autoKillReason -CurrentTimeZone $currentTimeZone `
+            -TargetTimeZone $targetTimeZone -TimeZoneSynced $timeZoneSynced `
+            -TimeZoneChangeFailed $timeZoneChangeFailed -TimeZoneChangedTo $timeZoneChangedTo
 
         $deadline = (Get-Date).AddSeconds($RefreshSeconds)
         :waitLoop while ((Get-Date) -lt $deadline) {
@@ -236,6 +358,11 @@ try {
                 switch ($key) {
                     'K' {
                         Stop-ClaudeProcesses
+                        break waitLoop
+                    }
+                    'T' {
+                        $timeZoneAttemptedFor = $null
+                        $timeZoneChangedTo = $null
                         break waitLoop
                     }
                     'X' {

--- a/claude-watch.sh
+++ b/claude-watch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Continuously monitor Claude processes and VPN connectivity on macOS.
+# Continuously monitor Claude processes, VPN connectivity, and time zone on macOS.
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -10,6 +10,8 @@ BOLD='\033[1m'
 RESET='\033[0m'
 
 REFRESH_SECONDS=2
+REQUIRED_TIMEZONE='America/New_York'
+HOME_TIMEZONE='Asia/Tehran'
 
 cleanup() {
     printf '\033[?25h\033[?1049l%bMonitor stopped.%b\n' "$CYAN" "$RESET"
@@ -74,6 +76,46 @@ vpn_status() {
     return 1
 }
 
+get_timezone() {
+    local timezone_link
+
+    timezone_link=$(readlink /etc/localtime 2>/dev/null) || return 1
+    case "$timezone_link" in
+        */zoneinfo/*) printf '%s' "${timezone_link#*/zoneinfo/}" ;;
+        *) return 1 ;;
+    esac
+}
+
+target_timezone_for_vpn() {
+    if [[ "$1" == true ]]; then
+        printf '%s' "$REQUIRED_TIMEZONE"
+    else
+        printf '%s' "$HOME_TIMEZONE"
+    fi
+}
+
+set_timezone() {
+    local target_timezone="$1"
+    local target_name="$2"
+    local change_status
+
+    # Leave the alternate screen so macOS can show sudo's password prompt.
+    printf '\033[?25h\033[?1049l\n'
+    printf 'The network state requires the %s time zone.\n' "$target_name"
+    printf 'Enter your Mac administrator password to change it to %s.\n' "$target_timezone"
+
+    sudo /usr/sbin/systemsetup -settimezone "$target_timezone"
+    change_status=$?
+
+    if [[ $change_status -eq 0 ]]; then
+        sudo /usr/sbin/systemsetup -setnetworktimeserver time.apple.com >/dev/null 2>&1 || true
+        sudo /usr/sbin/systemsetup -setusingnetworktime on >/dev/null 2>&1 || true
+    fi
+
+    printf '\033[?1049h\033[2J\033[H\033[?25l'
+    [[ $change_status -eq 0 && "$(get_timezone)" == "$target_timezone" ]]
+}
+
 kill_claude() {
     local pids
     pids=$(claude_pids)
@@ -90,7 +132,28 @@ kill_claude() {
     done
 }
 
+invoke_self_test() {
+    [[ "$(target_timezone_for_vpn true)" == "$REQUIRED_TIMEZONE" ]] || return 1
+    [[ "$(target_timezone_for_vpn false)" == "$HOME_TIMEZONE" ]] || return 1
+    [[ -n "$(get_timezone)" ]] || return 1
+    [[ -e "/usr/share/zoneinfo/$REQUIRED_TIMEZONE" ]] || return 1
+    [[ -e "/usr/share/zoneinfo/$HOME_TIMEZONE" ]] || return 1
+    command -v pgrep >/dev/null 2>&1 || return 1
+    command -v scutil >/dev/null 2>&1 || return 1
+    command -v systemsetup >/dev/null 2>&1 || return 1
+    printf 'Claude Watch macOS self-test passed.\n'
+}
+
+if [[ "${1:-}" == '--self-test' ]]; then
+    invoke_self_test
+    exit $?
+fi
+
 printf '\033[?1049h\033[2J\033[H\033[?25l'
+
+timezone_attempted_for=''
+timezone_changed_to=''
+timezone_change_failed=false
 
 while true; do
     printf '\033[H'
@@ -99,24 +162,67 @@ while true; do
     vpn=''
     vpn_connected=false
     auto_killed=false
+    auto_kill_reason=''
+    timezone=$(get_timezone)
+    timezone_ready=false
+    timezone_synced=false
+
+    if [[ "$timezone" == "$REQUIRED_TIMEZONE" ]]; then
+        timezone_ready=true
+    fi
 
     if vpn=$(vpn_status); then
         vpn_connected=true
+        target_timezone_name='New York'
+    else
+        target_timezone_name='Tehran'
+    fi
+    target_timezone=$(target_timezone_for_vpn "$vpn_connected")
+
+    if [[ "$timezone" == "$target_timezone" ]]; then
+        timezone_synced=true
+        timezone_attempted_for=''
+        timezone_change_failed=false
     fi
 
-    if [[ -n "$pids" && "$vpn_connected" == false ]]; then
+    # Claude is allowed only when both the VPN and New York time zone are ready.
+    if [[ -n "$pids" && ("$vpn_connected" == false || "$timezone_ready" == false) ]]; then
         kill_claude
         auto_killed=true
+        if [[ "$vpn_connected" == false ]]; then
+            auto_kill_reason='the VPN is disconnected'
+        else
+            auto_kill_reason="the time zone is ${timezone:-unknown}, not $REQUIRED_TIMEZONE"
+        fi
         pids=$(claude_pids)
     fi
 
-    printf '\033[2K%b\n' "${BOLD}${CYAN}macOS Claude + VPN Monitor${RESET}"
+    # Keep New York time while protected by VPN, and Tehran time otherwise.
+    if [[ "$timezone_synced" == false && "$timezone_attempted_for" != "$target_timezone" ]]; then
+        timezone_attempted_for="$target_timezone"
+        if set_timezone "$target_timezone" "$target_timezone_name"; then
+            timezone=$(get_timezone)
+            timezone_synced=true
+            timezone_changed_to="$target_timezone"
+            timezone_change_failed=false
+            if [[ "$timezone" == "$REQUIRED_TIMEZONE" ]]; then
+                timezone_ready=true
+            else
+                timezone_ready=false
+            fi
+        else
+            timezone=$(get_timezone)
+            timezone_change_failed=true
+        fi
+    fi
+
+    printf '\033[2K%b\n' "${BOLD}${CYAN}macOS Claude + VPN + Time Zone Monitor${RESET}"
     printf '\033[2KUpdated: %s  |  Refresh: %ss\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$REFRESH_SECONDS"
     printf '\033[2K\n'
 
     if [[ -n "$pids" ]]; then
         process_count=$(printf '%s\n' "$pids" | wc -l | tr -d ' ')
-        if [[ "$vpn_connected" == true ]]; then
+        if [[ "$vpn_connected" == true && "$timezone_ready" == true ]]; then
             claude_color="$YELLOW"
         else
             claude_color="$RED"
@@ -132,7 +238,7 @@ while true; do
     fi
 
     if [[ "$auto_killed" == true ]]; then
-        printf '\033[2K%b\n' "${RED}${BOLD}Claude was automatically stopped because the VPN is disconnected.${RESET}"
+        printf '\033[2K%b\n' "${RED}${BOLD}Claude was automatically stopped because ${auto_kill_reason}.${RESET}"
     fi
 
     printf '\033[2K\n'
@@ -142,15 +248,44 @@ while true; do
         printf '\033[2K%b\n' "${RED}${BOLD}VPN: Not connected — Claude auto-kill is armed${RESET}"
     fi
 
+    if [[ "$timezone_synced" == true ]]; then
+        printf '\033[2K%b\n' "${GREEN}${BOLD}TIME ZONE: ${timezone}${RESET}"
+    else
+        printf '\033[2K%b\n' "${RED}${BOLD}TIME ZONE: ${timezone:-Unknown} — expected ${target_timezone}${RESET}"
+    fi
+
+    if [[ "$vpn_connected" == true && "$timezone_ready" == true ]]; then
+        if [[ "$timezone_changed_to" == "$REQUIRED_TIMEZONE" ]]; then
+            printf '\033[2K%b\n' "${GREEN}${BOLD}READY: Time zone changed to New York. You can open Claude now.${RESET}"
+        else
+            printf '\033[2K%b\n' "${GREEN}${BOLD}READY: VPN and New York time zone confirmed. You can open Claude.${RESET}"
+        fi
+    elif [[ "$vpn_connected" == false && "$timezone_synced" == true ]]; then
+        printf '\033[2K%b\n' "${RED}${BOLD}SAFE: Time zone is Tehran. Claude remains blocked until VPN connects.${RESET}"
+    elif [[ "$timezone_change_failed" == true ]]; then
+        printf '\033[2K%b\n' "${RED}${BOLD}Time zone change failed. Claude remains blocked; press [t] to retry.${RESET}"
+    else
+        printf '\033[2K\n'
+    fi
+
     printf '\033[2K\n'
-    printf '\033[2K%s\n' 'Options: [k] Kill all Claude processes   [x] Exit'
+    printf '\033[2K%s\n' 'Options: [k] Kill Claude   [t] Sync time zone   [x] Exit'
     printf '\033[2K%s' 'Choice (monitor keeps refreshing): '
     printf '\033[J'
+
+    if [[ ! -t 0 ]]; then
+        sleep "$REFRESH_SECONDS"
+        continue
+    fi
 
     choice=''
     if IFS= read -r -s -n 1 -t "$REFRESH_SECONDS" choice; then
         case "$choice" in
             k|K) kill_claude ;;
+            t|T)
+                timezone_attempted_for=''
+                timezone_changed_to=''
+                ;;
             x|X|q|Q) cleanup ;;
         esac
     fi


### PR DESCRIPTION
## What changed

- Added VPN-aware time-zone enforcement on macOS and Windows.
- Claude is allowed only when a VPN is connected and the system time zone is New York.
- When the VPN connects, the monitor switches the system to New York time.
- When the VPN disconnects, Claude is stopped and the monitor switches the system back to Tehran time.
- Added explicit ready, safe, failure, and retry states.
- Added macOS and Windows self-tests to the compatibility workflow.
- Fixed the Windows detector to use process names rather than command-line matching, consistent with the macOS false-positive fix.

## Safety behavior

The monitor follows two deterministic states:

- VPN connected + New York time: Claude allowed.
- VPN disconnected + Tehran time: Claude blocked.

Claude is stopped before correcting an inconsistent time zone. If macOS administrator authentication or Windows UAC approval is declined, Claude remains blocked and the monitor does not repeatedly prompt; users can press `t` to retry.

## Validation

- Both macOS scripts pass `bash -n` and their non-destructive self-tests.
- A real macOS fixture process named `Claude` was stopped while VPN was connected and the system was set to Tehran.
- The macOS failure path was verified without administrator credentials: no ready state was displayed and Claude remained blocked.
- GitHub Actions validates macOS Bash and Windows PowerShell behavior on their native runners.
