### PR TITLE
Make time zone protection optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ chmod +x claude-watch.sh
 ./claude-watch.sh
 ```
 
+To disable time-zone protection for the entire run without any administrator prompt:
+
+```bash
+./claude-watch.sh --no-timezone
+```
+
 ## Windows
 
 Requirements: Windows 10 or 11 and Windows PowerShell 5.1 or later.
@@ -37,6 +43,12 @@ Clone the repository, open PowerShell in its folder, and run:
 
 ```powershell
 powershell -NoProfile -ExecutionPolicy Bypass -File .\claude-watch.ps1
+```
+
+To disable time-zone protection for the entire run without UAC prompts:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\claude-watch.ps1 -NoTimeZone
 ```
 
 The execution-policy option applies only to that invocation and does not change the system policy.
@@ -62,7 +74,9 @@ Claude Watch keeps the system in one of two explicit states:
 | Connected | New York (`America/New_York` on macOS; `Eastern Standard Time` on Windows) | Allowed |
 | Disconnected | Tehran (`Asia/Tehran` on macOS; `Iran Standard Time` on Windows) | Blocked |
 
-Claude is stopped before an inconsistent time zone is corrected. If administrator authorization is declined or the change cannot be verified, Claude remains blocked and the monitor offers a manual retry with `t`.
+Reading the current time zone never requires administrator access. If it already matches the VPN state, Claude Watch continues without requesting elevation. Only when a change is needed does Claude Watch explain why elevated access is required and offer three choices: change it, skip time-zone protection for the current session without elevation, or exit.
+
+Claude is stopped before an approved inconsistent time zone is corrected. If administrator authorization is declined or the change cannot be verified, Claude remains blocked and the monitor offers a manual retry with `t`. Choosing skip disables only the time-zone rules; VPN protection remains active.
 
 ## VPN detection on macOS
 

--- a/claude-watch.ps1
+++ b/claude-watch.ps1
@@ -2,7 +2,8 @@
 
 [CmdletBinding()]
 param(
-    [switch]$SelfTest
+    [switch]$SelfTest,
+    [switch]$NoTimeZone
 )
 
 $RefreshSeconds = 2
@@ -81,6 +82,47 @@ function Set-ClaudeWatchTimeZone {
     }
     catch {
         return $false
+    }
+}
+
+function Request-TimeZoneAction {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$CurrentTimeZone,
+
+        [Parameter(Mandatory = $true)]
+        [string]$TargetTimeZone
+    )
+
+    try {
+        [Console]::CursorVisible = $true
+        [Console]::Clear()
+        Write-Host 'Time-zone protection found a mismatch.' -ForegroundColor Yellow
+        Write-Host ''
+        Write-Host "Current time zone:  $CurrentTimeZone"
+        Write-Host "Required time zone: $TargetTimeZone"
+        Write-Host ''
+        Write-Host 'Reading the current time zone does not require administrator access.'
+        Write-Host 'Windows requires administrator approval only to change this system-wide setting.'
+        Write-Host ''
+        Write-Host '[C] Change the time zone (Windows UAC approval required)'
+        Write-Host '[S] Skip time-zone protection for this session (no elevation)'
+        Write-Host '[X] Exit Claude Watch'
+        Write-Host ''
+        $choice = Read-Host 'Choice [C/S/X]'
+    }
+    catch {
+        $choice = 'S'
+    }
+    finally {
+        [Console]::Clear()
+        [Console]::CursorVisible = $false
+    }
+
+    switch ($choice) {
+        { $_ -match '(?i)^c$' } { return 'Change' }
+        { $_ -match '(?i)^(x|q)$' } { return 'Exit' }
+        default { return 'Skip' }
     }
 }
 
@@ -180,7 +222,8 @@ function Show-Status {
         [string]$TargetTimeZone,
         [bool]$TimeZoneSynced,
         [bool]$TimeZoneChangeFailed,
-        [string]$TimeZoneChangedTo
+        [string]$TimeZoneChangedTo,
+        [bool]$TimeZoneEnforced
     )
 
     [Console]::SetCursorPosition(0, 0)
@@ -191,7 +234,7 @@ function Show-Status {
     if ($ClaudeProcesses.Count -eq 0) {
         Write-StatusLine 'No Claude processes are running.' Green
     }
-    elseif ($VpnStatus -and $CurrentTimeZone -eq $RequiredTimeZone) {
+    elseif ($VpnStatus -and ((-not $TimeZoneEnforced) -or $CurrentTimeZone -eq $RequiredTimeZone)) {
         Write-StatusLine ('CLAUDE IS RUNNING: {0} process(es)' -f $ClaudeProcesses.Count) Yellow
     }
     else {
@@ -214,20 +257,29 @@ function Show-Status {
     }
 
     Write-StatusLine ''
-    if ($TimeZoneSynced) {
+    if (-not $TimeZoneEnforced) {
+        Write-StatusLine ('TIME ZONE: {0} - protection skipped for this session' -f $CurrentTimeZone) Yellow
+    }
+    elseif ($TimeZoneSynced) {
         Write-StatusLine ('TIME ZONE: {0}' -f $CurrentTimeZone) Green
     }
     else {
         Write-StatusLine ('TIME ZONE: {0} - expected {1}' -f $CurrentTimeZone, $TargetTimeZone) Red
     }
 
-    if ($VpnStatus -and $CurrentTimeZone -eq $RequiredTimeZone) {
+    if ($VpnStatus -and -not $TimeZoneEnforced) {
+        Write-StatusLine 'READY: VPN confirmed. Time-zone protection is disabled. You can open Claude.' Green
+    }
+    elseif ($VpnStatus -and $CurrentTimeZone -eq $RequiredTimeZone) {
         if ($TimeZoneChangedTo -eq $RequiredTimeZone) {
             Write-StatusLine 'READY: Time zone changed to New York. You can open Claude now.' Green
         }
         else {
             Write-StatusLine 'READY: VPN and New York time zone confirmed. You can open Claude.' Green
         }
+    }
+    elseif (-not $VpnStatus -and -not $TimeZoneEnforced) {
+        Write-StatusLine 'SAFE: VPN is disconnected. Claude remains blocked.' Red
     }
     elseif (-not $VpnStatus -and $TimeZoneSynced) {
         Write-StatusLine 'SAFE: Time zone is Tehran. Claude remains blocked until VPN connects.' Red
@@ -240,7 +292,7 @@ function Show-Status {
     }
 
     Write-StatusLine ''
-    Write-StatusLine 'Options: [K] Kill Claude   [T] Sync time zone   [X] Exit'
+    Write-StatusLine 'Options: [K] Kill Claude   [T] Enable/sync time zone   [X] Exit'
     Write-StatusLine 'Monitor keeps refreshing automatically.'
 }
 
@@ -300,6 +352,7 @@ $exitRequested = $false
 $timeZoneAttemptedFor = $null
 $timeZoneChangedTo = $null
 $timeZoneChangeFailed = $false
+$timeZoneEnforcement = -not $NoTimeZone
 
 try {
     [Console]::Clear()
@@ -319,37 +372,63 @@ try {
             $timeZoneChangeFailed = $false
         }
 
-        if ($claudeProcesses.Count -gt 0 -and
-            ((-not $vpnStatus) -or $currentTimeZone -ne $RequiredTimeZone)) {
+        if ($claudeProcesses.Count -gt 0 -and -not $vpnStatus) {
             Stop-ClaudeProcesses
             $autoKilled = $true
-            if (-not $vpnStatus) {
-                $autoKillReason = 'the VPN is disconnected'
-            }
-            else {
-                $autoKillReason = "the time zone is $currentTimeZone, not $RequiredTimeZone"
-            }
+            $autoKillReason = 'the VPN is disconnected'
             $claudeProcesses = @(Get-ClaudeProcesses)
         }
 
-        if (-not $timeZoneSynced -and $timeZoneAttemptedFor -ne $targetTimeZone) {
+        if ($timeZoneEnforcement -and -not $timeZoneSynced -and $timeZoneAttemptedFor -ne $targetTimeZone) {
             $timeZoneAttemptedFor = $targetTimeZone
-            if (Set-ClaudeWatchTimeZone $targetTimeZone) {
-                $currentTimeZone = (Get-TimeZone).Id
-                $timeZoneSynced = $true
-                $timeZoneChangedTo = $targetTimeZone
-                $timeZoneChangeFailed = $false
+            $timeZoneAction = Request-TimeZoneAction -CurrentTimeZone $currentTimeZone -TargetTimeZone $targetTimeZone
+            switch ($timeZoneAction) {
+                'Skip' {
+                    $timeZoneEnforcement = $false
+                    $timeZoneChangeFailed = $false
+                }
+                'Exit' {
+                    $exitRequested = $true
+                }
+                'Change' {
+                    if ($claudeProcesses.Count -gt 0) {
+                        Stop-ClaudeProcesses
+                        $autoKilled = $true
+                        $autoKillReason = "time-zone protection requires $RequiredTimeZone"
+                        $claudeProcesses = @(Get-ClaudeProcesses)
+                    }
+
+                    if (Set-ClaudeWatchTimeZone $targetTimeZone) {
+                        $currentTimeZone = (Get-TimeZone).Id
+                        $timeZoneSynced = $true
+                        $timeZoneChangedTo = $targetTimeZone
+                        $timeZoneChangeFailed = $false
+                    }
+                    else {
+                        $currentTimeZone = (Get-TimeZone).Id
+                        $timeZoneChangeFailed = $true
+                    }
+                }
             }
-            else {
-                $currentTimeZone = (Get-TimeZone).Id
-                $timeZoneChangeFailed = $true
-            }
+        }
+
+        if ($exitRequested) {
+            continue
+        }
+
+        if ($claudeProcesses.Count -gt 0 -and $vpnStatus -and $timeZoneEnforcement -and
+            $currentTimeZone -ne $RequiredTimeZone) {
+            Stop-ClaudeProcesses
+            $autoKilled = $true
+            $autoKillReason = "the time zone is $currentTimeZone, not $RequiredTimeZone"
+            $claudeProcesses = @(Get-ClaudeProcesses)
         }
 
         Show-Status -ClaudeProcesses $claudeProcesses -VpnStatus $vpnStatus -AutoKilled $autoKilled `
             -AutoKillReason $autoKillReason -CurrentTimeZone $currentTimeZone `
             -TargetTimeZone $targetTimeZone -TimeZoneSynced $timeZoneSynced `
-            -TimeZoneChangeFailed $timeZoneChangeFailed -TimeZoneChangedTo $timeZoneChangedTo
+            -TimeZoneChangeFailed $timeZoneChangeFailed -TimeZoneChangedTo $timeZoneChangedTo `
+            -TimeZoneEnforced $timeZoneEnforcement
 
         $deadline = (Get-Date).AddSeconds($RefreshSeconds)
         :waitLoop while ((Get-Date) -lt $deadline) {
@@ -361,6 +440,7 @@ try {
                         break waitLoop
                     }
                     'T' {
+                        $timeZoneEnforcement = $true
                         $timeZoneAttemptedFor = $null
                         $timeZoneChangedTo = $null
                         break waitLoop

--- a/claude-watch.sh
+++ b/claude-watch.sh
@@ -116,6 +116,37 @@ set_timezone() {
     [[ $change_status -eq 0 && "$(get_timezone)" == "$target_timezone" ]]
 }
 
+request_timezone_action() {
+    local target_timezone="$1"
+    local target_name="$2"
+    local current_timezone="$3"
+    local choice
+
+    printf '\033[?25h\033[?1049l\n'
+    printf 'Time-zone protection found a mismatch.\n\n'
+    printf 'Current time zone:  %s\n' "${current_timezone:-Unknown}"
+    printf 'Required time zone: %s (%s)\n\n' "$target_name" "$target_timezone"
+    printf 'Reading the current time zone does not require administrator access.\n'
+    printf 'macOS requires administrator access only to change this system-wide setting.\n\n'
+    printf '[c] Change the time zone (administrator password required)\n'
+    printf '[s] Skip time-zone protection for this session (no sudo)\n'
+    printf '[x] Exit Claude Watch\n\n'
+
+    if [[ -t 0 ]]; then
+        IFS= read -r -p 'Choice [c/s/x]: ' choice
+    else
+        choice='s'
+        printf 'No interactive terminal detected; skipping time-zone protection for this session.\n'
+    fi
+
+    printf '\033[?1049h\033[2J\033[H\033[?25l'
+    case "$choice" in
+        c|C) timezone_action='change' ;;
+        x|X|q|Q) timezone_action='exit' ;;
+        *) timezone_action='skip' ;;
+    esac
+}
+
 kill_claude() {
     local pids
     pids=$(claude_pids)
@@ -147,6 +178,11 @@ invoke_self_test() {
 if [[ "${1:-}" == '--self-test' ]]; then
     invoke_self_test
     exit $?
+fi
+
+timezone_enforcement=true
+if [[ "${1:-}" == '--no-timezone' ]]; then
+    timezone_enforcement=false
 fi
 
 printf '\033[?1049h\033[2J\033[H\033[?25l'
@@ -185,35 +221,59 @@ while true; do
         timezone_change_failed=false
     fi
 
-    # Claude is allowed only when both the VPN and New York time zone are ready.
-    if [[ -n "$pids" && ("$vpn_connected" == false || "$timezone_ready" == false) ]]; then
+    # A disconnected VPN always blocks Claude, regardless of time-zone preference.
+    if [[ -n "$pids" && "$vpn_connected" == false ]]; then
         kill_claude
         auto_killed=true
-        if [[ "$vpn_connected" == false ]]; then
-            auto_kill_reason='the VPN is disconnected'
-        else
-            auto_kill_reason="the time zone is ${timezone:-unknown}, not $REQUIRED_TIMEZONE"
-        fi
+        auto_kill_reason='the VPN is disconnected'
         pids=$(claude_pids)
     fi
 
-    # Keep New York time while protected by VPN, and Tehran time otherwise.
-    if [[ "$timezone_synced" == false && "$timezone_attempted_for" != "$target_timezone" ]]; then
+    # Ask before requesting elevated access. Skipping disables this protection
+    # for the current session and guarantees that sudo will not be called.
+    if [[ "$timezone_enforcement" == true && "$timezone_synced" == false && "$timezone_attempted_for" != "$target_timezone" ]]; then
         timezone_attempted_for="$target_timezone"
-        if set_timezone "$target_timezone" "$target_timezone_name"; then
-            timezone=$(get_timezone)
-            timezone_synced=true
-            timezone_changed_to="$target_timezone"
-            timezone_change_failed=false
-            if [[ "$timezone" == "$REQUIRED_TIMEZONE" ]]; then
-                timezone_ready=true
-            else
-                timezone_ready=false
-            fi
-        else
-            timezone=$(get_timezone)
-            timezone_change_failed=true
-        fi
+        request_timezone_action "$target_timezone" "$target_timezone_name" "$timezone"
+        case "$timezone_action" in
+            skip)
+                timezone_enforcement=false
+                timezone_change_failed=false
+                ;;
+            exit)
+                cleanup
+                ;;
+            change)
+                if [[ -n "$pids" ]]; then
+                    kill_claude
+                    auto_killed=true
+                    auto_kill_reason="time-zone protection requires $REQUIRED_TIMEZONE"
+                    pids=$(claude_pids)
+                fi
+                if set_timezone "$target_timezone" "$target_timezone_name"; then
+                    timezone=$(get_timezone)
+                    timezone_synced=true
+                    timezone_changed_to="$target_timezone"
+                    timezone_change_failed=false
+                    if [[ "$timezone" == "$REQUIRED_TIMEZONE" ]]; then
+                        timezone_ready=true
+                    else
+                        timezone_ready=false
+                    fi
+                else
+                    timezone=$(get_timezone)
+                    timezone_change_failed=true
+                fi
+                ;;
+        esac
+    fi
+
+    # If protected time-zone correction failed, newly opened Claude processes
+    # remain blocked until the user retries or skips this protection.
+    if [[ -n "$pids" && "$vpn_connected" == true && "$timezone_enforcement" == true && "$timezone_ready" == false ]]; then
+        kill_claude
+        auto_killed=true
+        auto_kill_reason="the time zone is ${timezone:-unknown}, not $REQUIRED_TIMEZONE"
+        pids=$(claude_pids)
     fi
 
     printf '\033[2K%b\n' "${BOLD}${CYAN}macOS Claude + VPN + Time Zone Monitor${RESET}"
@@ -222,7 +282,7 @@ while true; do
 
     if [[ -n "$pids" ]]; then
         process_count=$(printf '%s\n' "$pids" | wc -l | tr -d ' ')
-        if [[ "$vpn_connected" == true && "$timezone_ready" == true ]]; then
+        if [[ "$vpn_connected" == true && ("$timezone_enforcement" == false || "$timezone_ready" == true) ]]; then
             claude_color="$YELLOW"
         else
             claude_color="$RED"
@@ -248,18 +308,24 @@ while true; do
         printf '\033[2K%b\n' "${RED}${BOLD}VPN: Not connected — Claude auto-kill is armed${RESET}"
     fi
 
-    if [[ "$timezone_synced" == true ]]; then
+    if [[ "$timezone_enforcement" == false ]]; then
+        printf '\033[2K%b\n' "${YELLOW}${BOLD}TIME ZONE: ${timezone:-Unknown} — protection skipped for this session${RESET}"
+    elif [[ "$timezone_synced" == true ]]; then
         printf '\033[2K%b\n' "${GREEN}${BOLD}TIME ZONE: ${timezone}${RESET}"
     else
         printf '\033[2K%b\n' "${RED}${BOLD}TIME ZONE: ${timezone:-Unknown} — expected ${target_timezone}${RESET}"
     fi
 
-    if [[ "$vpn_connected" == true && "$timezone_ready" == true ]]; then
+    if [[ "$vpn_connected" == true && "$timezone_enforcement" == false ]]; then
+        printf '\033[2K%b\n' "${GREEN}${BOLD}READY: VPN confirmed. Time-zone protection is disabled. You can open Claude.${RESET}"
+    elif [[ "$vpn_connected" == true && "$timezone_ready" == true ]]; then
         if [[ "$timezone_changed_to" == "$REQUIRED_TIMEZONE" ]]; then
             printf '\033[2K%b\n' "${GREEN}${BOLD}READY: Time zone changed to New York. You can open Claude now.${RESET}"
         else
             printf '\033[2K%b\n' "${GREEN}${BOLD}READY: VPN and New York time zone confirmed. You can open Claude.${RESET}"
         fi
+    elif [[ "$vpn_connected" == false && "$timezone_enforcement" == false ]]; then
+        printf '\033[2K%b\n' "${RED}${BOLD}SAFE: VPN is disconnected. Claude remains blocked.${RESET}"
     elif [[ "$vpn_connected" == false && "$timezone_synced" == true ]]; then
         printf '\033[2K%b\n' "${RED}${BOLD}SAFE: Time zone is Tehran. Claude remains blocked until VPN connects.${RESET}"
     elif [[ "$timezone_change_failed" == true ]]; then
@@ -269,7 +335,7 @@ while true; do
     fi
 
     printf '\033[2K\n'
-    printf '\033[2K%s\n' 'Options: [k] Kill Claude   [t] Sync time zone   [x] Exit'
+    printf '\033[2K%s\n' 'Options: [k] Kill Claude   [t] Enable/sync time zone   [x] Exit'
     printf '\033[2K%s' 'Choice (monitor keeps refreshing): '
     printf '\033[J'
 
@@ -283,6 +349,7 @@ while true; do
         case "$choice" in
             k|K) kill_claude ;;
             t|T)
+                timezone_enforcement=true
                 timezone_attempted_for=''
                 timezone_changed_to=''
                 ;;


### PR DESCRIPTION
## What changed

- Time-zone reads remain non-privileged on both macOS and Windows.
- If the current time zone already matches the VPN state, the monitor continues without requesting administrator access.
- Before any system time-zone change, the monitor explains why elevation is needed and asks the user to choose:
  - change the time zone with administrator approval;
  - skip time-zone protection for the current session without elevation; or
  - exit.
- Added `--no-timezone` on macOS and `-NoTimeZone` on Windows for fully non-privileged runs.
- Pressing `t` re-enables time-zone protection after it was skipped.
- VPN auto-kill protection always remains active, even when time-zone protection is skipped.

## Safety behavior

Skipping time-zone protection never invokes `sudo` or Windows UAC. It disables only the time-zone rules for that process lifetime. A disconnected VPN still stops Claude immediately.

If a user approves time-zone correction, Claude is stopped before the privileged change. If authorization fails, Claude remains blocked until the user retries or explicitly skips the time-zone rule.

## Validation

- macOS syntax and self-tests pass locally.
- The interactive skip path was tested with a connected VPN and Tehran time: no sudo prompt appeared, the time zone stayed unchanged, and the monitor reported that only time-zone protection was disabled.
- The `--no-timezone` path was tested and started without any elevation prompt.
- GitHub Actions validates the PowerShell changes on a native Windows runner.
