### PR TITLE
Add Iran time zone restore option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ The execution-policy option applies only to that invocation and does not change 
 ## Controls
 
 - Press `k` to stop every detected Claude process.
-- Press `t` to retry synchronizing the time zone with the VPN state.
+- Press `t` to prepare New York time before opening Claude or retry synchronization.
+- Press `i` to restore Iran time while Claude is closed.
 - Press `x` or `q` to exit.
 
 ## Status colors
@@ -77,6 +78,8 @@ Claude Watch keeps the system in one of two explicit states:
 Reading the current time zone never requires administrator access. If it already matches the VPN state, Claude Watch continues without requesting elevation. Only when a change is needed does Claude Watch explain why elevated access is required and offer three choices: change it, skip time-zone protection for the current session without elevation, or exit.
 
 Claude is stopped before an approved inconsistent time zone is corrected. If administrator authorization is declined or the change cannot be verified, Claude remains blocked and the monitor offers a manual retry with `t`. Choosing skip disables only the time-zone rules; VPN protection remains active.
+
+When Claude is closed, pressing `i` restores the Tehran/Iran time zone even if the VPN remains connected. This state is held instead of being immediately changed back. Press `t` to prepare New York time before opening Claude. If Claude starts while Iran time is being held, Claude Watch releases the hold and runs the normal New York safety flow.
 
 ## VPN detection on macOS
 

--- a/claude-watch.ps1
+++ b/claude-watch.ps1
@@ -44,13 +44,21 @@ function Get-ClaudeProcesses {
 }
 
 function Get-TargetTimeZone {
-    param([AllowNull()][string]$VpnStatus)
+    param(
+        [AllowNull()][string]$VpnStatus,
+        [bool]$IranHold = $false,
+        [bool]$ClaudeRunning = $false
+    )
 
-    if ($VpnStatus) {
-        return $RequiredTimeZone
+    if (-not $VpnStatus) {
+        return $HomeTimeZone
     }
 
-    return $HomeTimeZone
+    if ($IranHold -and -not $ClaudeRunning) {
+        return $HomeTimeZone
+    }
+
+    return $RequiredTimeZone
 }
 
 function Set-ClaudeWatchTimeZone {
@@ -223,7 +231,8 @@ function Show-Status {
         [bool]$TimeZoneSynced,
         [bool]$TimeZoneChangeFailed,
         [string]$TimeZoneChangedTo,
-        [bool]$TimeZoneEnforced
+        [bool]$TimeZoneEnforced,
+        [bool]$IranHold
     )
 
     [Console]::SetCursorPosition(0, 0)
@@ -267,7 +276,10 @@ function Show-Status {
         Write-StatusLine ('TIME ZONE: {0} - expected {1}' -f $CurrentTimeZone, $TargetTimeZone) Red
     }
 
-    if ($VpnStatus -and -not $TimeZoneEnforced) {
+    if ($VpnStatus -and $TimeZoneEnforced -and $IranHold -and $TimeZoneSynced -and $ClaudeProcesses.Count -eq 0) {
+        Write-StatusLine 'STANDBY: Iran time is restored. Press [T] to prepare New York before opening Claude.' Yellow
+    }
+    elseif ($VpnStatus -and -not $TimeZoneEnforced) {
         Write-StatusLine 'READY: VPN confirmed. Time-zone protection is disabled. You can open Claude.' Green
     }
     elseif ($VpnStatus -and $CurrentTimeZone -eq $RequiredTimeZone) {
@@ -292,7 +304,12 @@ function Show-Status {
     }
 
     Write-StatusLine ''
-    Write-StatusLine 'Options: [K] Kill Claude   [T] Enable/sync time zone   [X] Exit'
+    if ($ClaudeProcesses.Count -eq 0) {
+        Write-StatusLine 'Options: [K] Kill   [T] Prepare New York   [I] Restore Iran   [X] Exit'
+    }
+    else {
+        Write-StatusLine 'Options: [K] Kill   [T] Prepare New York   [X] Exit'
+    }
     Write-StatusLine 'Monitor keeps refreshing automatically.'
 }
 
@@ -332,8 +349,10 @@ function Invoke-SelfTest {
     if (Test-ClaudeProcess $otherSample) { throw 'Unrelated process detection failed.' }
     if (-not (Test-VpnAdapter $vpnSample)) { throw 'VPN adapter detection failed.' }
     if (Test-VpnAdapter $ethernetSample) { throw 'Unrelated adapter detection failed.' }
-    if ((Get-TargetTimeZone 'Connected: Test VPN') -ne $RequiredTimeZone) { throw 'VPN time-zone target failed.' }
-    if ((Get-TargetTimeZone $null) -ne $HomeTimeZone) { throw 'Disconnected time-zone target failed.' }
+    if ((Get-TargetTimeZone 'Connected: Test VPN' $false $false) -ne $RequiredTimeZone) { throw 'VPN time-zone target failed.' }
+    if ((Get-TargetTimeZone 'Connected: Test VPN' $true $false) -ne $HomeTimeZone) { throw 'Iran hold target failed.' }
+    if ((Get-TargetTimeZone 'Connected: Test VPN' $true $true) -ne $RequiredTimeZone) { throw 'Claude release of Iran hold failed.' }
+    if ((Get-TargetTimeZone $null $false $false) -ne $HomeTimeZone) { throw 'Disconnected time-zone target failed.' }
     if (-not (Get-TimeZone -ListAvailable | Where-Object { $_.Id -eq $RequiredTimeZone })) { throw 'New York time-zone ID is unavailable.' }
     if (-not (Get-TimeZone -ListAvailable | Where-Object { $_.Id -eq $HomeTimeZone })) { throw 'Tehran time-zone ID is unavailable.' }
 
@@ -353,6 +372,7 @@ $timeZoneAttemptedFor = $null
 $timeZoneChangedTo = $null
 $timeZoneChangeFailed = $false
 $timeZoneEnforcement = -not $NoTimeZone
+$iranHold = $false
 
 try {
     [Console]::Clear()
@@ -364,7 +384,11 @@ try {
         $autoKilled = $false
         $autoKillReason = $null
         $currentTimeZone = (Get-TimeZone).Id
-        $targetTimeZone = Get-TargetTimeZone $vpnStatus
+        if ($claudeProcesses.Count -gt 0) {
+            $iranHold = $false
+        }
+
+        $targetTimeZone = Get-TargetTimeZone $vpnStatus $iranHold ($claudeProcesses.Count -gt 0)
         $timeZoneSynced = ($currentTimeZone -eq $targetTimeZone)
 
         if ($timeZoneSynced) {
@@ -428,7 +452,7 @@ try {
             -AutoKillReason $autoKillReason -CurrentTimeZone $currentTimeZone `
             -TargetTimeZone $targetTimeZone -TimeZoneSynced $timeZoneSynced `
             -TimeZoneChangeFailed $timeZoneChangeFailed -TimeZoneChangedTo $timeZoneChangedTo `
-            -TimeZoneEnforced $timeZoneEnforcement
+            -TimeZoneEnforced $timeZoneEnforcement -IranHold $iranHold
 
         $deadline = (Get-Date).AddSeconds($RefreshSeconds)
         :waitLoop while ((Get-Date) -lt $deadline) {
@@ -441,8 +465,18 @@ try {
                     }
                     'T' {
                         $timeZoneEnforcement = $true
+                        $iranHold = $false
                         $timeZoneAttemptedFor = $null
                         $timeZoneChangedTo = $null
+                        break waitLoop
+                    }
+                    'I' {
+                        if ($claudeProcesses.Count -eq 0) {
+                            $timeZoneEnforcement = $true
+                            $iranHold = $true
+                            $timeZoneAttemptedFor = $null
+                            $timeZoneChangedTo = $null
+                        }
                         break waitLoop
                     }
                     'X' {

--- a/claude-watch.sh
+++ b/claude-watch.sh
@@ -88,12 +88,26 @@ get_timezone() {
     esac
 }
 
-target_timezone_for_vpn() {
-    if [[ "$1" == true ]]; then
-        printf '%s' "$REQUIRED_TIMEZONE"
-    else
-        printf '%s' "$HOME_TIMEZONE"
-    fi
+target_timezone_for_state() {
+    local stable_vpn_state="$1"
+    local hold_iran="$2"
+    local claude_running="$3"
+
+    case "$stable_vpn_state" in
+        disconnected)
+            printf '%s' "$HOME_TIMEZONE"
+            ;;
+        connected)
+            if [[ "$hold_iran" == true && "$claude_running" == false ]]; then
+                printf '%s' "$HOME_TIMEZONE"
+            else
+                printf '%s' "$REQUIRED_TIMEZONE"
+            fi
+            ;;
+        *)
+            return 1
+            ;;
+    esac
 }
 
 update_vpn_state() {
@@ -189,8 +203,11 @@ kill_claude() {
 }
 
 invoke_self_test() {
-    [[ "$(target_timezone_for_vpn true)" == "$REQUIRED_TIMEZONE" ]] || return 1
-    [[ "$(target_timezone_for_vpn false)" == "$HOME_TIMEZONE" ]] || return 1
+    [[ "$(target_timezone_for_state connected false false)" == "$REQUIRED_TIMEZONE" ]] || return 1
+    [[ "$(target_timezone_for_state connected true false)" == "$HOME_TIMEZONE" ]] || return 1
+    [[ "$(target_timezone_for_state connected true true)" == "$REQUIRED_TIMEZONE" ]] || return 1
+    [[ "$(target_timezone_for_state disconnected false false)" == "$HOME_TIMEZONE" ]] || return 1
+    target_timezone_for_state unknown false false >/dev/null 2>&1 && return 1
     [[ -n "$(get_timezone)" ]] || return 1
     [[ -e "/usr/share/zoneinfo/$REQUIRED_TIMEZONE" ]] || return 1
     [[ -e "/usr/share/zoneinfo/$HOME_TIMEZONE" ]] || return 1
@@ -241,6 +258,7 @@ timezone_change_failed=false
 vpn_state='unknown'
 vpn_misses=0
 vpn_grace_until=0
+iran_hold=false
 
 while true; do
     printf '\033[H'
@@ -266,22 +284,23 @@ while true; do
     fi
     update_vpn_state "$raw_vpn_connected"
 
-    case "$vpn_state" in
-        connected)
-            target_timezone="$REQUIRED_TIMEZONE"
-            target_timezone_name='New York'
-            timezone_target_known=true
-            ;;
-        disconnected)
-            target_timezone="$HOME_TIMEZONE"
+    if [[ -n "$pids" ]]; then
+        iran_hold=false
+    fi
+
+    claude_running=false
+    [[ -n "$pids" ]] && claude_running=true
+    if target_timezone=$(target_timezone_for_state "$vpn_state" "$iran_hold" "$claude_running"); then
+        timezone_target_known=true
+        if [[ "$target_timezone" == "$HOME_TIMEZONE" ]]; then
             target_timezone_name='Tehran'
-            timezone_target_known=true
-            ;;
-        *)
-            target_timezone=''
-            target_timezone_name=''
-            ;;
-    esac
+        else
+            target_timezone_name='New York'
+        fi
+    else
+        target_timezone=''
+        target_timezone_name=''
+    fi
 
     if [[ "$timezone_target_known" == true && "$timezone" == "$target_timezone" ]]; then
         timezone_synced=true
@@ -389,7 +408,9 @@ while true; do
         printf '\033[2K%b\n' "${RED}${BOLD}TIME ZONE: ${timezone:-Unknown} — expected ${target_timezone}${RESET}"
     fi
 
-    if [[ "$vpn_connected" == true && "$timezone_enforcement" == false ]]; then
+    if [[ "$vpn_connected" == true && "$timezone_enforcement" == true && "$iran_hold" == true && "$timezone_synced" == true && -z "$pids" ]]; then
+        printf '\033[2K%b\n' "${YELLOW}${BOLD}STANDBY: Iran time is restored. Press [t] to prepare New York before opening Claude.${RESET}"
+    elif [[ "$vpn_connected" == true && "$timezone_enforcement" == false ]]; then
         printf '\033[2K%b\n' "${GREEN}${BOLD}READY: VPN confirmed. Time-zone protection is disabled. You can open Claude.${RESET}"
     elif [[ "$vpn_connected" == true && "$timezone_ready" == true ]]; then
         if [[ "$timezone_changed_to" == "$REQUIRED_TIMEZONE" ]]; then
@@ -408,7 +429,11 @@ while true; do
     fi
 
     printf '\033[2K\n'
-    printf '\033[2K%s\n' 'Options: [k] Kill Claude   [t] Enable/sync time zone   [x] Exit'
+    if [[ -z "$pids" ]]; then
+        printf '\033[2K%s\n' 'Options: [k] Kill   [t] Prepare New York   [i] Restore Iran   [x] Exit'
+    else
+        printf '\033[2K%s\n' 'Options: [k] Kill   [t] Prepare New York   [x] Exit'
+    fi
     printf '\033[2K%s' 'Choice (monitor keeps refreshing): '
     printf '\033[J'
 
@@ -423,8 +448,17 @@ while true; do
             k|K) kill_claude ;;
             t|T)
                 timezone_enforcement=true
+                iran_hold=false
                 timezone_attempted_for=''
                 timezone_changed_to=''
+                ;;
+            i|I)
+                if [[ -z "$pids" ]]; then
+                    timezone_enforcement=true
+                    iran_hold=true
+                    timezone_attempted_for=''
+                    timezone_changed_to=''
+                fi
                 ;;
             x|X|q|Q) cleanup ;;
         esac


### PR DESCRIPTION
## Summary
- add Restore Iran and Prepare New York controls on macOS and Windows
- show Restore Iran only while Claude is closed
- hold Tehran after an explicit restore, even while the VPN stays connected
- release that hold if Claude starts, so the normal VPN and New York safety checks run
- preserve automatic New York preparation during ordinary VPN reconnects

## Validation
- macOS Bash syntax check
- macOS self-test for repository and installed copies
- interactive macOS test of the Restore Iran and no-sudo Skip path
- Git diff validation
- Windows PowerShell validation will run in GitHub Actions